### PR TITLE
adding support for service aliases

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/dic/ServiceMapParser.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/dic/ServiceMapParser.java
@@ -47,6 +47,10 @@ public class ServiceMapParser {
             if (!(node.hasAttribute("public") && node.getAttribute("public").equals("false"))) {
                 publicMap.put(node.getAttribute("id"), "\\" + node.getAttribute("class"));
             }
+            if (node.hasAttribute("alias") && publicMap.get(node.getAttribute("alias")) != null) {
+                map.put(node.getAttribute("id"), map.get(node.getAttribute("alias")));
+                publicMap.put(node.getAttribute("id"), map.get(node.getAttribute("alias")));
+            }
         }
 
         // Support services whose class isn't specified

--- a/tests/fr/adrienbrault/idea/symfony2plugin/tests/dic/ServiceMapParserTest.java
+++ b/tests/fr/adrienbrault/idea/symfony2plugin/tests/dic/ServiceMapParserTest.java
@@ -20,6 +20,7 @@ public class ServiceMapParserTest extends Assert {
             "<container>" +
                 "<service id=\"adrienbrault\" class=\"AdrienBrault\\Awesome\"/>" +
                 "<service id=\"secret\" class=\"AdrienBrault\\Secret\" public=\"false\"/>" +
+                "<service id=\"translator\" alias=\"adrienbrault\"/>" +
             "</container>";
         ServiceMap serviceMap = serviceMapParser.parse(new ByteArrayInputStream(xmlString.getBytes()));
 
@@ -37,6 +38,9 @@ public class ServiceMapParserTest extends Assert {
         assertEquals("\\Symfony\\Component\\DependencyInjection\\ContainerInterface", serviceMap.getPublicMap().get("service_container"));
         assertEquals("\\Symfony\\Component\\HttpKernel\\KernelInterface", serviceMap.getMap().get("kernel"));
         assertEquals("\\Symfony\\Component\\HttpKernel\\KernelInterface", serviceMap.getPublicMap().get("kernel"));
+
+        assertEquals("\\AdrienBrault\\Awesome", serviceMap.getMap().get("translator"));
+        assertEquals("\\AdrienBrault\\Awesome", serviceMap.getPublicMap().get("translator"));
     }
 
 }


### PR DESCRIPTION
service aliases like the `translator` were not added to the service map. so here the fix+testing to support them
