### PR TITLE
another fix for ide freeze

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/dic/SymfonyContainerTypeProvider.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/dic/SymfonyContainerTypeProvider.java
@@ -1,7 +1,9 @@
 package fr.adrienbrault.idea.symfony2plugin.dic;
 
 import com.intellij.openapi.project.DumbService;
+import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
+import com.jetbrains.php.lang.parser.PhpElementTypes;
 import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider;
@@ -23,6 +25,22 @@ public class SymfonyContainerTypeProvider implements PhpTypeProvider {
     @Override
     public PhpType getType(PsiElement e) {
         if (DumbService.getInstance(e.getProject()).isDumb()) {
+            return null;
+        }
+
+        // filter out method calls without parameter
+        // $this->get('service_name')
+        if(!PlatformPatterns.psiElement(PhpElementTypes.METHOD_REFERENCE).withChild(
+                PlatformPatterns.psiElement(PhpElementTypes.PARAMETER_LIST).withFirstChild(
+                        PlatformPatterns.psiElement(PhpElementTypes.STRING))).accepts(e)) {
+
+            return null;
+        }
+
+        // container calls are only on "get" methods
+        // cant we move it up to PlatformPatterns? withName condition dont looks working
+        String methodRefName = ((MethodReference) e).getName();
+        if(methodRefName == null || !methodRefName.equals("get")) {
             return null;
         }
 


### PR DESCRIPTION
see #32
i think this one is a better solution. the other breaks the isCallTo method. two changes:
- check for valid ContainerCalls with PlatformPatterns (ide looks faster now)
- in isCallTo check for called method name before resolve (i hope i dont break the idea of this method)

the depth check can be removed, you try to remove the freeze with this?
