### PR TITLE
settings can disable phptypes

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/Settings.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/Settings.java
@@ -26,6 +26,10 @@ public class Settings implements PersistentStateComponent<Settings> {
     public String pathToProjectContainer = DEFAULT_CONTAINER_PATH;
     public String pathToUrlGenerator = DEFAULT_URL_GENERATOR_PATH;
 
+    public boolean symfonyContainerTypeProvider = true;
+    public boolean objectRepositoryTypeProvider = false;
+    public boolean objectRepositoryResultTypeProvider = false;
+
     protected Project project;
 
     public static Settings getInstance(Project project) {

--- a/src/fr/adrienbrault/idea/symfony2plugin/SettingsForm.form
+++ b/src/fr/adrienbrault/idea/symfony2plugin/SettingsForm.form
@@ -20,6 +20,8 @@
         <rowspec value="center:max(d;4px):noGrow"/>
         <rowspec value="top:4dlu:noGrow"/>
         <rowspec value="center:max(d;4px):noGrow"/>
+        <rowspec value="top:4dlu:noGrow"/>
+        <rowspec value="center:max(d;4px):noGrow"/>
         <colspec value="fill:max(d;4px):noGrow"/>
         <colspec value="left:4dlu:noGrow"/>
         <colspec value="fill:d:grow"/>
@@ -87,32 +89,40 @@
             </constraints>
             <properties/>
           </component>
-          <component id="733dc" class="javax.swing.JCheckBox" binding="checkBoxContainerTypes">
-            <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-              <forms/>
-            </constraints>
-            <properties>
-              <enabled value="true"/>
-              <text value="Container"/>
-            </properties>
-          </component>
-          <component id="21819" class="javax.swing.JCheckBox" binding="checkBoxGetRepositoryTypes">
-            <constraints>
-              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-              <forms/>
-            </constraints>
-            <properties>
-              <text value="Repository"/>
-            </properties>
-          </component>
-          <component id="59e9b" class="javax.swing.JCheckBox" binding="checkBoxGetRepositoryResultTypes">
+          <component id="21819" class="javax.swing.JCheckBox" binding="objectRepositoryTypeProvider">
             <constraints>
               <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
               <forms/>
             </constraints>
             <properties>
-              <text value="RepositoryTypes"/>
+              <text value="Repository Entity"/>
+            </properties>
+          </component>
+          <component id="59e9b" class="javax.swing.JCheckBox" binding="objectRepositoryResultTypeProvider">
+            <constraints>
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <forms/>
+            </constraints>
+            <properties>
+              <text value="ObjectRepository (find*)"/>
+            </properties>
+          </component>
+          <component id="d0415" class="javax.swing.JLabel" binding="typesLabel">
+            <constraints>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <forms/>
+            </constraints>
+            <properties>
+              <text value="PhpTypes Resolver"/>
+            </properties>
+          </component>
+          <component id="7d2c2" class="javax.swing.JCheckBox" binding="symfonyContainerTypeProvider">
+            <constraints>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <forms/>
+            </constraints>
+            <properties>
+              <text value="Container Service"/>
             </properties>
           </component>
         </children>

--- a/src/fr/adrienbrault/idea/symfony2plugin/SettingsForm.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/SettingsForm.java
@@ -24,10 +24,13 @@ public class SettingsForm implements Configurable {
     private TextFieldWithBrowseButton pathToContainerTextField;
     private JButton pathToContainerTextFieldReset;
     private JButton pathToUrlGeneratorTextFieldReset;
-    private JCheckBox checkBoxContainerTypes;
-    private JCheckBox checkBoxGetRepositoryTypes;
-    private JCheckBox checkBoxGetRepositoryResultTypes;
+
+    private JCheckBox symfonyContainerTypeProvider;
+    private JCheckBox objectRepositoryTypeProvider;
+    private JCheckBox objectRepositoryResultTypeProvider;
+
     private TextFieldWithBrowseButton pathToUrlGeneratorTextField;
+    private JLabel typesLabel;
 
     public SettingsForm(@NotNull final Project project) {
         this.project = project;
@@ -61,6 +64,9 @@ public class SettingsForm implements Configurable {
         return
             !pathToContainerTextField.getText().equals(getSettings().pathToProjectContainer)
             || !pathToUrlGeneratorTextField.getText().equals(getSettings().pathToUrlGenerator)
+            || !symfonyContainerTypeProvider.isSelected() == getSettings().symfonyContainerTypeProvider
+            || !objectRepositoryTypeProvider.isSelected() == getSettings().objectRepositoryTypeProvider
+            || !objectRepositoryResultTypeProvider.isSelected() == getSettings().objectRepositoryResultTypeProvider
         ;
     }
 
@@ -68,6 +74,10 @@ public class SettingsForm implements Configurable {
     public void apply() throws ConfigurationException {
         getSettings().pathToProjectContainer = pathToContainerTextField.getText();
         getSettings().pathToUrlGenerator = pathToUrlGeneratorTextField.getText();
+
+        getSettings().symfonyContainerTypeProvider = symfonyContainerTypeProvider.isSelected();
+        getSettings().objectRepositoryTypeProvider = objectRepositoryTypeProvider.isSelected();
+        getSettings().objectRepositoryResultTypeProvider = objectRepositoryResultTypeProvider.isSelected();
     }
 
     @Override
@@ -77,8 +87,6 @@ public class SettingsForm implements Configurable {
 
     @Override
     public void disposeUIResources() {
-        pathToContainerTextField = null;
-        pathToUrlGeneratorTextField = null;
     }
 
     private Settings getSettings() {
@@ -88,6 +96,10 @@ public class SettingsForm implements Configurable {
     private void updateUIFromSettings() {
         pathToContainerTextField.setText(getSettings().pathToProjectContainer);
         pathToUrlGeneratorTextField.setText(getSettings().pathToUrlGenerator);
+
+        symfonyContainerTypeProvider.setSelected(getSettings().symfonyContainerTypeProvider);
+        objectRepositoryTypeProvider.setSelected(getSettings().objectRepositoryTypeProvider);
+        objectRepositoryResultTypeProvider.setSelected(getSettings().objectRepositoryResultTypeProvider);
     }
 
     private MouseListener createPathButtonMouseListener(final JTextField textField) {
@@ -155,4 +167,5 @@ public class SettingsForm implements Configurable {
             }
         };
     }
+
 }

--- a/src/fr/adrienbrault/idea/symfony2plugin/dic/SymfonyContainerTypeProvider.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/dic/SymfonyContainerTypeProvider.java
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiElement;
 import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider;
+import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2InterfacesUtil;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
@@ -20,7 +21,7 @@ public class SymfonyContainerTypeProvider implements PhpTypeProvider {
     @Nullable
     @Override
     public PhpType getType(PsiElement e) {
-        if (DumbService.getInstance(e.getProject()).isDumb()) {
+        if (DumbService.getInstance(e.getProject()).isDumb() || !Settings.getInstance(e.getProject()).symfonyContainerTypeProvider) {
             return null;
         }
 

--- a/src/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
@@ -8,6 +8,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider;
+import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2InterfacesUtil;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,7 +22,7 @@ public class ObjectRepositoryResultTypeProvider implements PhpTypeProvider {
     @Nullable
     @Override
     public PhpType getType(PsiElement e) {
-        if (DumbService.getInstance(e.getProject()).isDumb()) {
+        if (DumbService.getInstance(e.getProject()).isDumb() || !Settings.getInstance(e.getProject()).objectRepositoryResultTypeProvider) {
             return null;
         }
 

--- a/src/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryTypeProvider.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryTypeProvider.java
@@ -6,6 +6,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider;
+import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2InterfacesUtil;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
 import org.jetbrains.annotations.Nullable;
@@ -19,7 +20,7 @@ public class ObjectRepositoryTypeProvider implements PhpTypeProvider {
     @Nullable
     @Override
     public PhpType getType(PsiElement e) {
-        if (DumbService.getInstance(e.getProject()).isDumb()) {
+        if (DumbService.getInstance(e.getProject()).isDumb() || !Settings.getInstance(e.getProject()).objectRepositoryTypeProvider) {
             return null;
         }
 


### PR DESCRIPTION
i completely refactored the settings form to be usable in the design. So its easier to manage it :). after that i added the possibility to disable all phptypes. the doctrine types defaults are now disabled. #52

![designer](https://f.cloud.github.com/assets/1011712/489022/91b2bcf6-b98d-11e2-9311-a2018151ae09.png)
