### PR TITLE
Downgrade for IDEA version

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -223,7 +223,7 @@
     </change-notes>
 
     <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="129.757"/>
+    <idea-version since-build="129.713"/>
 
     <extensions defaultExtensionNs="com.intellij">
 


### PR DESCRIPTION
This change allows the plugin to be installed in latest IntelliJ IDEA v12 (12.1.4) as the build number is 129.713 and PHPStorm is 129.757.

There should be no problem in installing this in the latest stable PHPStorm.

Thanks.
