### PR TITLE
Changed propertyMapping 'column' to 'name'

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/config/doctrine/DoctrineStaticTypeLookupBuilder.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/config/doctrine/DoctrineStaticTypeLookupBuilder.java
@@ -78,7 +78,7 @@ public class DoctrineStaticTypeLookupBuilder {
     }
 
     public ArrayList<LookupElement> getPropertyMappings() {
-        return ListToElements(Arrays.asList("type", "column", "length", "unique", "nullable", "precision", "scale", "columnDefinition"));
+        return ListToElements(Arrays.asList("type", "name", "length", "unique", "nullable", "precision", "scale", "columnDefinition"));
     }
 
     public ArrayList<LookupElement> ListToElements(List<String> items) {


### PR DESCRIPTION
In according to Doctrine's documentation, the column name should use attribute 'name' instead of 'column',

e.g.

```
/**
* @ORM\Column(name="my_field")
*/
protected $field;
```

instead of

```
/**
* @ORM\Column(column="my_field")
*/
protected $field;
```

See http://docs.doctrine-project.org/en/latest/reference/annotations-reference.html#annref-column
