### PR TITLE
[Form] Fixed wrong Inspection for FormTypeExtensions

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/util/dict/ServiceUtil.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/util/dict/ServiceUtil.java
@@ -43,7 +43,7 @@ public class ServiceUtil {
         put("doctrine.event_listener", null);
         put("doctrine.event_subscriber", null);
         put("form.type", "\\Symfony\\Component\\Form\\FormTypeInterface");
-        put("form.type_extension", "\\Symfony\\Component\\Form\\FormExtensionInterface");
+        put("form.type_extension", "\\Symfony\\Component\\Form\\FormTypeExtensionInterface");
         put("form.type_guesser", "\\Symfony\\Component\\Form\\FormTypeGuesserInterface");
         put("kernel.cache_clearer", null);
         put("kernel.cache_warmer", "\\Symfony\\Component\\HttpKernel\\CacheWarmer\\CacheWarmerInterface");


### PR DESCRIPTION
FormTypeExtensions must implement `\Symfony\Component\Form\FormTypeExtensionInterface` not `\Symfony\Component\Form\FormExtensionInterface`. Symfony's abstract class `AbstractTypeExtension` does this aswell.
See http://symfony.com/doc/current/reference/dic_tags.html#form-type-extension
and http://symfony.com/doc/current/cookbook/form/create_form_type_extension.html

![image](https://cloud.githubusercontent.com/assets/4896363/7220463/29859e40-e6c8-11e4-84a4-53b1d9a0cc90.png)
