### PR TITLE
[Fix] Remove double Controller in classname

### DIFF
--- a/src/resources/fileTemplates/controller.php
+++ b/src/resources/fileTemplates/controller.php
@@ -4,7 +4,7 @@ namespace {{ ns }};
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
-class {{ class }}Controller extends Controller
+class {{ class }} extends Controller
 {
     public function indexAction($name)
     {


### PR DESCRIPTION
When generating a new Controller (right clicking a folder), the classname had a double Controller word in it. eg. TestControllerController.
This removes one of them.