### PR TITLE
add translator.logging parameter

### DIFF
--- a/src/resources/symfony2-config.xml
+++ b/src/resources/symfony2-config.xml
@@ -167,6 +167,7 @@
     <translator
         enabled="false"
         fallback="en"
+        logging = "%kernel.debug%"
     />
 
     <!-- validation configuration -->


### PR DESCRIPTION
according to http://symfony.com/blog/new-in-symfony-2-6-improvements-for-the-translation-component#missing-translations-logging