### PR TITLE
fix container config

### DIFF
--- a/src/resources/fileTemplates/container.yml
+++ b/src/resources/fileTemplates/container.yml
@@ -1,12 +1,9 @@
-parameters:
-#    {{ BundleNameUnderscore }}.example.class: {{ BundleName }}\Example
-
 services:
 #    {{ BundleNameUnderscore }}.example:
-#        class: %{{ BundleNameUnderscore }}.example.class%
-#        arguments: [@service_id, "plain_value", %parameter%]
+#        class:     {{ BundleName }}\Example
+#        arguments: ["@service_id", "plain_value", "%parameter%"]
 #        calls:
-#            - [setService, [@service_id]]
+#            - [setService, ["@service_id"]]
 #        tags:
 #            - { name: twig.extension }
 #            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }


### PR DESCRIPTION
1.: according the symfony best practices, parameters for class names should be avoided: http://symfony.com/doc/current/best_practices/business-logic.html#service-no-class-parameter
2.: service and parameter expressions in yaml must be quoted: http://symfony.com/doc/current/best_practices/business-logic.html#service-no-class-parameter