### PR TITLE
PhpUse#getOriginal is deprecated, use #getFQN instead

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/AnnotationRoutesStubIndex.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/AnnotationRoutesStubIndex.java
@@ -118,9 +118,9 @@ public class AnnotationRoutesStubIndex extends FileBasedIndexExtension<String, R
             private void visitUse(PhpUse phpUse) {
                 String alias = phpUse.getAliasName();
                 if(alias != null) {
-                    useImports.put(alias, phpUse.getOriginal());
+                    useImports.put(alias, phpUse.getFQN());
                 } else {
-                    useImports.put(phpUse.getName(), phpUse.getOriginal());
+                    useImports.put(phpUse.getName(), phpUse.getFQN());
                 }
 
             }

--- a/src/fr/adrienbrault/idea/symfony2plugin/util/AnnotationBackportUtil.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/util/AnnotationBackportUtil.java
@@ -80,9 +80,9 @@ public class AnnotationBackportUtil {
             private void visitUse(PhpUse phpUse) {
                 String alias = phpUse.getAliasName();
                 if (alias != null) {
-                    useImports.put(alias, phpUse.getOriginal());
+                    useImports.put(alias, phpUse.getFQN());
                 } else {
-                    useImports.put(phpUse.getName(), phpUse.getOriginal());
+                    useImports.put(phpUse.getName(), phpUse.getFQN());
                 }
 
             }
@@ -115,9 +115,9 @@ public class AnnotationBackportUtil {
             private void visitUse(PhpUse phpUse) {
                 String alias = phpUse.getAliasName();
                 if (alias != null) {
-                    useImports.put(alias, phpUse.getOriginal());
+                    useImports.put(alias, phpUse.getFQN());
                 } else {
-                    useImports.put(phpUse.getName(), phpUse.getOriginal());
+                    useImports.put(phpUse.getName(), phpUse.getFQN());
                 }
 
             }


### PR DESCRIPTION
PhpUse#getOriginal is deprecated since PhpStorm 2016.1. This method was always returning almost the same value as #getFQN so this change most probably will not break anything. Unfortunately I've no chance to check it so it would be great if you'll perform some tests before or just after the merge. This pull request is rather notification than complete fix.