### PR TITLE
don't report standalone colon in mapping value

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/intentions/yaml/YamlUnquotedColon.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/intentions/yaml/YamlUnquotedColon.java
@@ -54,7 +54,7 @@ public class YamlUnquotedColon extends LocalInspectionTool {
             }
 
             String text = ((YAMLPlainTextImpl) plainScalar).getTextValue();
-            if(!text.contains(":")) {
+            if(!text.contains(": ")) {
                 super.visitElement(element);
                 return;
             }

--- a/tests/fr/adrienbrault/idea/symfony2plugin/tests/intentions/yaml/YamlUnquotedColonTest.java
+++ b/tests/fr/adrienbrault/idea/symfony2plugin/tests/intentions/yaml/YamlUnquotedColonTest.java
@@ -9,8 +9,15 @@ import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureT
  */
 public class YamlUnquotedColonTest extends SymfonyLightCodeInsightFixtureTestCase {
 
-    public void testColonInUnquotedMappingShouldDeprecated() {
+    public void testColonInUnquotedMappingFollowedBySpaceShouldDeprecated() {
         assertLocalInspectionContains("foo.yml",
+            "class: fo<caret>obar: fff",
+            YamlUnquotedColon.MESSAGE
+        );
+    }
+
+    public void testColonInUnquotedMappingNotFollowedBySpaceShouldNotDeprecated() {
+        assertLocalInspectionNotContains("foo.yml",
             "class: fo<caret>obar:fff",
             YamlUnquotedColon.MESSAGE
         );


### PR DESCRIPTION
Colons in mapping values are fine as long as they are not followed by a
space character.