### PR TITLE
[#810] Fixes the folder test for the cache

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/util/IdeHelper.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/util/IdeHelper.java
@@ -142,7 +142,7 @@ public class IdeHelper {
         Settings.getInstance(project).pluginEnabled = true;
 
         // Symfony 3.0 structure
-        if(VfsUtil.findRelativeFile(project.getBaseDir(), "var", "cache") == null) {
+        if(VfsUtil.findRelativeFile(project.getBaseDir(), "var", "cache") != null) {
             Settings.getInstance(project).pathToUrlGenerator = "var/cache/dev/appDevUrlGenerator.php";
             Settings.getInstance(project).pathToTranslation = "var/cache/dev/translations";
         }


### PR DESCRIPTION
Hello,

This PR to fix the test done on the cache folder for version 3.0. See #810 

The test indicates that if the var/cache folder does not exist (4274c9c), it becomes the default configuration.
The behavior must be reversed.

Regards