### PR TITLE
Adopt default routing files path to Symfony > 2.7.20

### DIFF
--- a/src/fr/adrienbrault/idea/symfony2plugin/Settings.java
+++ b/src/fr/adrienbrault/idea/symfony2plugin/Settings.java
@@ -22,18 +22,19 @@ import java.util.List;
 )
 public class Settings implements PersistentStateComponent<Settings> {
 
-    // Symfony 2 and 3 paths
+    // Default Symfony 2, 3 and 4 paths
     public static String[] DEFAULT_CONTAINER_PATHS = new String[] {
         "app/cache/dev/appDevDebugProjectContainer.xml",
         "var/cache/dev/appDevDebugProjectContainer.xml",
         "var/cache/dev/srcDevDebugProjectContainer.xml",
     };
 
-    // Symfony 2 and 3 paths
+    // Default Symfony 2, 3 and 4 paths
     public static String[] DEFAULT_ROUTES = new String[] {
         "app/cache/dev/appDevUrlGenerator.php",
         "var/cache/dev/appDevUrlGenerator.php",
-        "var/cache/dev/srcDevDebugProjectContainerUrlGenerator.php",   
+        "var/cache/dev/appDevDebugProjectContainerUrlGenerator.php",
+        "var/cache/dev/srcDevDebugProjectContainerUrlGenerator.php",
     };
 
     /**


### PR DESCRIPTION
Reflect changes, introduced in https://github.com/symfony/symfony/pull/20147

@stof Do you know any other paths that should be updated?

@Haehnchen imho it's time to remove deprecated option for url generator path.