### PR TITLE
Fix link to asset function

### DIFF
--- a/src/inspectionDescriptions/TwigAssetsTagMissingInspection.html
+++ b/src/inspectionDescriptions/TwigAssetsTagMissingInspection.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Asset not found. See <a href="http://symfony.com/doc/current/assetic/asset_management.html?phpstorm">Symfony documentation</a> for more information
+Asset not found. See <a href="http://symfony.com/doc/current/templating.html#linking-to-assets?phpstorm">Symfony documentation</a> for more information
 </body>
 </html>

--- a/src/inspectionDescriptions/TwigAssetsTagMissingInspection.html
+++ b/src/inspectionDescriptions/TwigAssetsTagMissingInspection.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Asset not found. See <a href="http://symfony.com/doc/current/templating.html#linking-to-assets?phpstorm">Symfony documentation</a> for more information
+Asset not found. See <a href="http://symfony.com/doc/current/templating.html?phpstorm#linking-to-assets">Symfony documentation</a> for more information
 </body>
 </html>


### PR DESCRIPTION
Asset function is not related to Assetic. Instead, it's related to Symfony Twig extension.
This PR makes the link pointing to correct documentation page