### PR TITLE
Prepare first gradle-based release (0.16.166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ Changelog
 * 0.10.x: PhpStorm 7 (no support)
 * 0.9.x: PhpStorm 6 (no support)
 
+## 0.16.166
+
+<ul>
+<li>28a81b49 Add 2018.3 to build matrix (Cedric Ziel)</li>
+<li>79623036 Inline Callback (Cedric Ziel)</li>
+<li>9a2e7042 Fixed Symfony installer version selection to use https (Thomas Schulz)</li>
+<li>0e8c1f44 Move back to JBList to support legacy platform (Cedric Ziel)</li>
+<li>243d9896 Move write action out of AWT event for PhpServiceArgumentIntention (Cedric Ziel)</li>
+<li>4b6c480d Adjust resource path for bundle file creation (Cedric Ziel)</li>
+<li>e8a58704 Remove unnecessary null check (Cedric Ziel)</li>
+<li>26e9e8b6 Update PHP plugin version to 182.3684.42 in 2018.2 build (Cedric Ziel)</li>
+<li>e8d51e22 Adapt to changed YAML Psi to find the first KeyValue mapping (Cedric Ziel)</li>
+<li>1eb302b0 Fix whitespace issues in fixtures (Cedric Ziel)</li>
+<li>88c8dc0b Update build environment to 2018.2 stable (Cedric Ziel)</li>
+<li>fba2ded5 Add YAML const GoTo Target for Symfony 3.2+ style constants (Cedric Ziel)</li>
+<li>6cdd1695 Add inspection and quick fix for fuzzy service class names (Cedric Ziel)</li>
+<li>4eda083a Remove unused imports (Cedric Ziel)</li>
+<li>9ccf2e55 Use adequate casing for sentence (Cedric Ziel)</li>
+<li>83475218 Drop unnecessary condition (Cedric Ziel)</li>
+<li>eed2fca0 When able to, detect Symfony 4 "public" directory (Cedric Ziel)</li>
+<li>1fb795a3 Small cleanups (Cedric Ziel)</li>
+<li>d46aadf9 Fix Yaml Inspection for deprecated structure (Cedric Ziel)</li>
+<li>6af47fd3 Update intelli gradle plugin to 0.3.3 (Cedric Ziel)</li>
+<li>eaa23c6d Add 2018.2 to build matrix (Cedric Ziel)</li>
+<li>147d6d09 Migrate Project structure to use gradle (#1164) (Cedric Ziel)</li>
+<li>1d727c39 fix travis 2017.3.x build (Daniel Espendiller)</li>
+<li>6f6a15fa Fix anchor/querystring order (Massimiliano Arione)</li>
+<li>ad7742e4 Fix link to asset function (Massimiliano Arione)</li></ul>
+
 ## 0.16.165
 * Prevent duplicate same targets in yaml targets eg for class navigation
 * Refactoring bundle loading, replacing HashMaps with ArrayList for non unique bundle project names

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,50 @@
+# Maintaining the plugin
+
+## Forging a new release
+
+The plugin is released manually, based on a git tag.
+
+A gradle plugin automatically determines the current tag and / or if this
+is a snapshot release.
+
+To build the plugin, execute the gradle task `buildPlugin`.
+
+```bash
+./gradlew clean buildPlugin
+```
+
+The artifact zip can then be found in `build/distrubutions`. This is the
+final result which can be uploaded to the JetBrains repository.
+
+The checklist for a new release should be the following:
+
+* ensure the project is currently on the latest commit on the `master` branch
+  You can enforce this by pulling and resetting with the `--hard` flag
+* make sure there are no staged changes
+* prepare the changelog:
+  * execute `./prepare-release.sh` to write the changelog to disk
+  * manually copy the relevant parts to `CHANGELOG.md`
+* commit the changed files (preferrable with a meaningful commit message 
+  `Prepare release 0.16.xxx`)
+* tag a release (`git tag 0.x.xxx`)
+* push the changed code and the tag to the remote (`git push && git push --tags`)
+* build the plugin on the tag (`./gradlew clean buildPlugin`)
+
+## Upload to JetBrain Plugin repository
+
+The plugin can be updated in two different ways.
+
+### Manual upload
+
+Upload the produced ZIP file to the JetBrains repository manually
+
+### Semi-automatic upload through gradle
+
+The IntelliJ gradle plugin ships a task to upload the release
+automatically. This will include the changelog generated earlier.
+
+Execute the following gradle task:
+
+```bash
+IJ_REPO_USERNAME=youruser IJ_REPO_PASSWORD=yourpassword ./gradlew clean buildPlugin publishPlugin
+```

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,11 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.3.3"
+    id "org.jetbrains.intellij" version "0.3.11"
+    id 'com.palantir.git-version' version "0.11.0"
 }
+
+def htmlFixer = { htmlFile -> file(htmlFile).text.replace('<html>', '').replace('</html>', '') }
 
 apply plugin: 'idea'
 apply plugin: 'org.jetbrains.intellij'
@@ -31,14 +34,26 @@ intellij {
             'properties'
     ]
     pluginName 'Symfony Plugin'
+}
 
-    patchPluginXml {
-        sinceBuild '173'
-    }
+patchPluginXml {
+    sinceBuild '173'
+    changeNotes = htmlFixer('src/main/resources/META-INF/change-notes.html')
+}
+
+publishPlugin {
+    username System.getenv('IJ_REPO_USERNAME')
+    password System.getenv('IJ_REPO_PASSWORD')
 }
 
 group 'fr.adrienbrault.idea.symfony2plugin'
-version '0.16.165'
+
+def details = versionDetails()
+if (details.isCleanTag) {
+    version = "${details.lastTag}"
+} else {
+    version = "${details.lastTag}.${details.gitHash}-SNAPSHOT"
+}
 
 wrapper {
     gradleVersion '4.3.1'

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+echo "<html><ul>" > change-notes.html
+git log `git describe --tags --abbrev=0`..HEAD --no-merges --oneline --pretty=format:"<li>%h %s (%an)</li>" >> change-notes.html
+echo "</ul></html>" >> change-notes.html
+
+cp change-notes.html src/main/resources/META-INF/
+
+rm change-notes.html

--- a/src/main/resources/META-INF/change-notes.html
+++ b/src/main/resources/META-INF/change-notes.html
@@ -1,0 +1,26 @@
+<html><ul>
+<li>28a81b49 Add 2018.3 to build matrix (Cedric Ziel)</li>
+<li>79623036 Inline Callback (Cedric Ziel)</li>
+<li>9a2e7042 Fixed Symfony installer version selection to use https (Thomas Schulz)</li>
+<li>0e8c1f44 Move back to JBList to support legacy platform (Cedric Ziel)</li>
+<li>243d9896 Move write action out of AWT event for PhpServiceArgumentIntention (Cedric Ziel)</li>
+<li>4b6c480d Adjust resource path for bundle file creation (Cedric Ziel)</li>
+<li>e8a58704 Remove unnecessary null check (Cedric Ziel)</li>
+<li>26e9e8b6 Update PHP plugin version to 182.3684.42 in 2018.2 build (Cedric Ziel)</li>
+<li>e8d51e22 Adapt to changed YAML Psi to find the first KeyValue mapping (Cedric Ziel)</li>
+<li>1eb302b0 Fix whitespace issues in fixtures (Cedric Ziel)</li>
+<li>88c8dc0b Update build environment to 2018.2 stable (Cedric Ziel)</li>
+<li>fba2ded5 Add YAML const GoTo Target for Symfony 3.2+ style constants (Cedric Ziel)</li>
+<li>6cdd1695 Add inspection and quick fix for fuzzy service class names (Cedric Ziel)</li>
+<li>4eda083a Remove unused imports (Cedric Ziel)</li>
+<li>9ccf2e55 Use adequate casing for sentence (Cedric Ziel)</li>
+<li>83475218 Drop unnecessary condition (Cedric Ziel)</li>
+<li>eed2fca0 When able to, detect Symfony 4 "public" directory (Cedric Ziel)</li>
+<li>1fb795a3 Small cleanups (Cedric Ziel)</li>
+<li>d46aadf9 Fix Yaml Inspection for deprecated structure (Cedric Ziel)</li>
+<li>6af47fd3 Update intelli gradle plugin to 0.3.3 (Cedric Ziel)</li>
+<li>eaa23c6d Add 2018.2 to build matrix (Cedric Ziel)</li>
+<li>147d6d09 Migrate Project structure to use gradle (#1164) (Cedric Ziel)</li>
+<li>1d727c39 fix travis 2017.3.x build (Daniel Espendiller)</li>
+<li>6f6a15fa Fix anchor/querystring order (Massimiliano Arione)</li>
+<li>ad7742e4 Fix link to asset function (Massimiliano Arione)</li></ul></html>


### PR DESCRIPTION
This changeset includes a few additions to the build chain, a word about releasing the plugin for maintainers, a script to generate the changelog between `HEAD` and the last release - and the changelog.

Once merged, I'll release a new version of the plugin to the repository.

Sorry this took so long to get to.