### PR TITLE
Do not set until constraint so EAP users can still use the plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ env:
   - PHPSTORM_ENV="skip incomplete" IDEA_VERSION="IU-2017.3.5" PHP_PLUGIN_VERSION="173.4301.34" TWIG_PLUGIN_VERSION="173.4301.7" TOOLBOX_PLUGIN_VERSION="0.4.6" ANNOTATION_PLUGIN_VERSION="5.2.1"
 
 script:
-- "./gradlew check buildPlugin"
+- "./gradlew check verifyPlugin buildPlugin"

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ apply plugin: 'java'
 
 intellij {
     version ideaVersion
+    updateSinceUntilBuild false
     plugins = [
             "com.jetbrains.php:${phpPluginVersion}",
             "com.jetbrains.twig:${twigPluginVersion}",


### PR DESCRIPTION
Also:

* add verifyPlugin task to travis build to avoid invalid plugin.xml