### PR TITLE
Don't mark an empty string for missing templates

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/PhpTemplateMissingInspection.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/PhpTemplateMissingInspection.java
@@ -39,7 +39,7 @@ public class PhpTemplateMissingInspection extends LocalInspectionTool {
 
     private void invoke(@NotNull ProblemsHolder holder, @NotNull PsiElement psiElement) {
         String templateNameIfMissing = getTemplateNameIfMissing(psiElement);
-        if(templateNameIfMissing == null) {
+        if(templateNameIfMissing == null || templateNameIfMissing.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
Fixes: #799