### PR TITLE
Symfony 4.2: Translation detection fixed for new TranslatorInterface namespace

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
@@ -56,7 +56,9 @@ import java.util.stream.Collectors;
 public class TranslationUtil {
     public static MethodMatcher.CallToSignature[] PHP_TRANSLATION_SIGNATURES = new MethodMatcher.CallToSignature[] {
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Translation\\TranslatorInterface", "trans"),
-        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Translation\\TranslatorInterface", "transChoice")
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Translation\\TranslatorInterface", "transChoice"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "trans"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "transChoice")
     };
 
     private static final String[] XLIFF_XPATH = {


### PR DESCRIPTION
For the upcoming Symfony 4.2 release, the `Symfony\Component\Translation\TranslatorInterface` became deprecated in favor of `Symfony\Contracts\Translation\TranslatorInterface`.

For the translation key detection to work again when injecting the new Translator, I added the new namespace.

For backwards compatibility for older Symfony versions, the "old" namespace stays in.