### PR TITLE
Fix service.xml creating

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/action/NewXmlServiceAction.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/action/NewXmlServiceAction.java
@@ -17,7 +17,7 @@ public class NewXmlServiceAction  extends AbstractProjectDumbAwareAction {
     @Override
     public void actionPerformed(AnActionEvent event) {
         final Project project = event.getData(PlatformDataKeys.PROJECT);
-        ServiceActionUtil.buildFile(event, project, "/resources/fileTemplates/container.xml");
+        ServiceActionUtil.buildFile(event, project, "/fileTemplates/container.xml");
     }
 
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/action/NewYamlServiceAction.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/action/NewYamlServiceAction.java
@@ -17,7 +17,7 @@ public class NewYamlServiceAction extends AbstractProjectDumbAwareAction {
     @Override
     public void actionPerformed(AnActionEvent event) {
         final Project project = event.getData(PlatformDataKeys.PROJECT);
-        ServiceActionUtil.buildFile(event, project, "/resources/fileTemplates/container.yml");
+        ServiceActionUtil.buildFile(event, project, "/fileTemplates/container.yml");
     }
 
 }


### PR DESCRIPTION
Since PhpStorm 2018.2 is the xml service creation broken. It cannot find the file. That makes me angry everytime when i need a services.xml

So here is the fix. It seems so that the /resources is not more needed anymore. I removed that, and he can find now the files.


I have also updated the Pipeline for PhpStorm 2018.3 release