### PR TITLE
Allow other plugins to extend container parameters

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/extension/ServiceParameterCollector.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/extension/ServiceParameterCollector.java
@@ -1,0 +1,13 @@
+package fr.adrienbrault.idea.symfony2plugin.extension;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public interface ServiceParameterCollector {
+    /**
+     * Warning expect high traffic, collector needs to be highly optimized
+     */
+    void collectIds(@NotNull ServiceParameterCollectorParameter.Id parameter);
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/extension/ServiceParameterCollectorParameter.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/extension/ServiceParameterCollectorParameter.java
@@ -1,0 +1,41 @@
+package fr.adrienbrault.idea.symfony2plugin.extension;
+
+import com.intellij.openapi.project.Project;
+import fr.adrienbrault.idea.symfony2plugin.dic.ContainerParameter;
+import fr.adrienbrault.idea.symfony2plugin.dic.container.SerializableService;
+import fr.adrienbrault.idea.symfony2plugin.dic.container.ServiceInterface;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class ServiceParameterCollectorParameter {
+    public static class Id {
+
+        @NotNull
+        private final Project project;
+
+        @NotNull
+        private final Collection<ContainerParameter> ids;
+
+        public Id(@NotNull Project project, @NotNull Collection<ContainerParameter> ids) {
+            this.project = project;
+            this.ids = ids;
+        }
+
+        @NotNull
+        public Project getProject() {
+            return project;
+        }
+
+        public void add(@NotNull ContainerParameter id) {
+            this.ids.add(id);
+        }
+
+        public void addAll(@NotNull Collection<ContainerParameter> names) {
+            this.ids.addAll(names);
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -548,6 +548,7 @@
         <extensionPoint name="extension.RoutingLoader" interface="fr.adrienbrault.idea.symfony2plugin.extension.RoutingLoader"/>
         <extensionPoint name="extension.CompiledServiceBuilderFactory" interface="fr.adrienbrault.idea.symfony2plugin.extension.CompiledServiceBuilderFactory"/>
         <extensionPoint name="extension.ServiceCollector" interface="fr.adrienbrault.idea.symfony2plugin.extension.ServiceCollector"/>
+        <extensionPoint name="extension.ServiceParameterCollector" interface="fr.adrienbrault.idea.symfony2plugin.extension.ServiceParameterCollector"/>
         <extensionPoint name="extension.ServiceDefinitionLocator" interface="fr.adrienbrault.idea.symfony2plugin.extension.ServiceDefinitionLocator"/>
         <extensionPoint name="extension.TwigVariableCollector" interface="fr.adrienbrault.idea.symfony2plugin.templating.variable.TwigFileVariableCollector"/>
     </extensionPoints>


### PR DESCRIPTION
## Why?
Other Plugins (in my case Shopware Plugin) can extend the parameters using the Extension Hookpoint.
The most code is copied from ServiceCollector extensionPoint

## Example
![image](https://user-images.githubusercontent.com/6224096/48921336-7da55c80-ee9f-11e8-91b3-da458b4ec67c.png)

```php
public class DefaultServiceParameterCollector implements ServiceParameterCollector {

    @Override
    public void collectIds(@NotNull ServiceParameterCollectorParameter.Id parameter) {
        parameter.add(new ContainerParameter("kernel.foo", "YAY", true));
    }
}
```