### PR TITLE
Allow custom getRepository()-like methods

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryTypeProvider.java
@@ -24,8 +24,6 @@ public class ObjectRepositoryTypeProvider implements PhpTypeProvider3 {
     private static MethodMatcher.CallToSignature[] GET_REPOSITORIES_SIGNATURES = new MethodMatcher.CallToSignature[] {
         new MethodMatcher.CallToSignature("\\Doctrine\\Common\\Persistence\\ManagerRegistry", "getRepository"),
         new MethodMatcher.CallToSignature("\\Doctrine\\Common\\Persistence\\ObjectManager", "getRepository"),
-        /*new MethodMatcher.CallToSignature("\\QsGeneralBundle\\Controller\\EntityController", "getRepo"),
-        new MethodMatcher.CallToSignature("\\QsGeneralBundle\\Controller\\SecurityController", "getRepo"),*/
     };
 
     private static String repositoryClass = "\\Doctrine\\Common\\Persistence\\ObjectRepository";
@@ -44,9 +42,7 @@ public class ObjectRepositoryTypeProvider implements PhpTypeProvider3 {
             return null;
         }
 
-        if(!(e instanceof MethodReference)
-                || (!PhpElementsUtil.isMethodWithFirstStringOrFieldReference(e, "getRepository")
-                    && !PhpElementsUtil.isMethodWithFirstStringOrFieldReference(e, "getRepo"))) {
+        if(!(e instanceof MethodReference)) {
             return null;
         }
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/doctrine/ObjectRepositoryTypeProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/doctrine/ObjectRepositoryTypeProviderTest.java
@@ -45,7 +45,6 @@ public class ObjectRepositoryTypeProviderTest extends SymfonyLightCodeInsightFix
                 "$em->getRepository(\\Foo\\Bar::class)->b<caret>ar();",
             PlatformPatterns.psiElement(Method.class).withName("bar")
         );
-
     }
 
     /**
@@ -58,6 +57,55 @@ public class ObjectRepositoryTypeProviderTest extends SymfonyLightCodeInsightFix
                 "/** @var \\Doctrine\\Common\\Persistence\\ObjectManager $em */\n" +
                 "$em->getRepository(\\Foo\\Bar::class)->b<caret>ar();",
             result
+        );
+    }
+
+    /**
+     * @see fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryTypeProvider
+     */
+    public void testGetRepositoryResolveByReturnTypeMethod() {
+        assertPhpReferenceResolveTo(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo('\\Foo\\Bar')->b<caret>ar();",
+                PlatformPatterns.psiElement(Method.class).withName("bar")
+        );
+
+        assertPhpReferenceSignatureContains(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo('\\Foo\\Bar')->b<caret>ar();",
+                "#M#" + '\u0151' + "#M#C\\Foo\\BarController.getRepo" + '\u0185' + "\\Foo\\Bar.bar"
+        );
+
+        assertPhpReferenceResolveTo(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo(\\Foo\\Bar::class)->b<caret>ar();",
+                PlatformPatterns.psiElement(Method.class).withName("bar")
+        );
+
+    }
+
+    public void testGetRepositoryNotResolveByWrongMethod() {
+        assertPhpReferenceNotResolveTo(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getBoo(\\Foo\\Bar::class)->b<caret>ar();",
+                PlatformPatterns.psiElement(Method.class).withName("bar")
+        );
+    }
+
+    /**
+     * @see fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryTypeProvider
+     */
+    public void testGetRepositoryResolveByReturnTypeMethodApiClassConstantCompatibility() {
+        String result = "#M#" + '\u0151' + "#M#C\\Foo\\BarController.getRepo" + '\u0185' + "#K#C\\Foo\\Bar.class.bar";
+
+        assertPhpReferenceSignatureContains(PhpFileType.INSTANCE, "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo(\\Foo\\Bar::class)->b<caret>ar();",
+                result
         );
     }
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/doctrine/ObjectRepositoryTypeProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/doctrine/ObjectRepositoryTypeProviderTest.java
@@ -45,7 +45,6 @@ public class ObjectRepositoryTypeProviderTest extends SymfonyLightCodeInsightFix
                 "$em->getRepository(\\Foo\\Bar::class)->b<caret>ar();",
             PlatformPatterns.psiElement(Method.class).withName("bar")
         );
-
     }
 
     /**
@@ -58,6 +57,58 @@ public class ObjectRepositoryTypeProviderTest extends SymfonyLightCodeInsightFix
                 "/** @var \\Doctrine\\Common\\Persistence\\ObjectManager $em */\n" +
                 "$em->getRepository(\\Foo\\Bar::class)->b<caret>ar();",
             result
+        );
+    }
+
+    /**
+     * @see fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryTypeProvider
+     */
+    public void testGetRepositoryResolveByReturnTypeMethod() {
+        //System.out.println("YESSSSSSS MONGAGA");
+        assertPhpReferenceResolveTo(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo('\\Foo\\Bar')->b<caret>ar();",
+                PlatformPatterns.psiElement(Method.class).withName("bar")
+        );
+
+        assertPhpReferenceSignatureContains(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo('\\Foo\\Bar')->b<caret>ar();",
+                "#M#" + '\u0151' + "#M#C\\Foo\\BarController.getRepo" + '\u0185' + "\\Foo\\Bar.bar"
+        );
+
+        assertPhpReferenceResolveTo(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo(\\Foo\\Bar::class)->b<caret>ar();",
+                PlatformPatterns.psiElement(Method.class).withName("bar")
+        );
+
+    }
+
+    public void testGetRepositoryNotResolveByWrongMethod() {
+        System.out.println("testGetRepositoryNotResolveByWrongMethod");
+
+        assertPhpReferenceNotResolveTo(PhpFileType.INSTANCE,
+                "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getBoo(\\Foo\\Bar::class)->b<caret>ar();",
+                PlatformPatterns.psiElement(Method.class).withName("bar")
+        );
+    }
+
+    /**
+     * @see fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryTypeProvider
+     */
+    public void testGetRepositoryResolveByReturnTypeMethodApiClassConstantCompatibility() {
+        String result = "#M#" + '\u0151' + "#M#C\\Foo\\BarController.getRepo" + '\u0185' + "#K#C\\Foo\\Bar.class.bar";
+
+        assertPhpReferenceSignatureContains(PhpFileType.INSTANCE, "<?php" +
+                        "/** @var \\Foo\\BarController $cont */\n" +
+                        "$cont->getRepo(\\Foo\\Bar::class)->b<caret>ar();",
+                result
         );
     }
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/doctrine/fixtures/classes.php
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/doctrine/fixtures/classes.php
@@ -11,13 +11,19 @@ namespace Doctrine\Common\Persistence {
 }
 
 namespace Foo {
-
     use Doctrine\Common\Persistence\ObjectRepository;
 
     abstract class Bar implements ObjectRepository {}
 
-    class BarRepository {
+    class BarRepository implements ObjectRepository {
         public function bar() {}
+    }
+
+    class WrongClass {}
+
+    class BarController {
+        public function getRepo($name): BarRepository {}
+        public function getBoo($name): WrongClass {}
     }
 }
 


### PR DESCRIPTION
getRepository() currently only support direct calls to `ManagerRegistry::getRepository` or `ObjectManager::getRepository`.
This PR supports other methods - typically shortcuts in Controllers - as soon as they use `ObjectRepository` or a child class as a PHP code return type.

Note : seems hard to support PHPDoc.

Example :
```
Class MyClass {
  public function getRepo($class): ObjectRepository {}
}

$c = new MyClass();
$c->getRepo(MyEntity::class)-> // Gives access to MyEntity repository methods
```