### PR TITLE
Bundle .phpstorm.meta.php files for new expectedArguments completion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/resources/symfony-meta"]
+	path = src/main/resources/symfony-meta
+	url = https://github.com/King2500/symfony-meta.git

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -120,6 +120,7 @@
         <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryResultTypeProvider"/>
         <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectManagerFindTypeProvider"/>
         <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.assistant.signature.MethodSignatureTypeProvider"/>
+        <libraryRoot id="symfony_meta" path="/symfony-meta/" runtime="false"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
PhpStorm 2019.1 introduces `expectedArguments` and `expectedReturnValues` meta definitions to allow for approciate completion of constants and string values.
See official blog post here:
https://blog.jetbrains.com/phpstorm/2019/02/new-phpstorm-meta-php-features/

I went through Symfony framework/components and defined a lot of them here:
https://github.com/King2500/symfony-meta

People can fetch them via Composer now (as require-dev), but I think it would be better to have these bundled into this plugin.
Advantages:
* No need to require them in every Symfony project
* No need to have this requirement in composer.json (because it's a PhpStorm-specific thing and developers may not want to have this dependency there, when working with other developers/IDEs)

I added symfony-meta repo as git-submodule so this can be updated easily in the future (`git submodule update`?).

It will be built in plugin as "Library" folder, so PhpStorm can index/read meta defintions, as described [here](https://confluence.jetbrains.com/display/PhpStorm/PhpStorm+Advanced+Metadata#PhpStormAdvancedMetadata-Packagingmetadata/stubfilesintoplugin).

![image](https://user-images.githubusercontent.com/4896363/54052820-bfa3a580-41e5-11e9-823e-5d55cc0e278f.png)


**Examples**
Here are some example screenshots where it comes in:
![image](https://user-images.githubusercontent.com/4896363/54052609-283e5280-41e5-11e9-9172-672463879322.png)

![image](https://user-images.githubusercontent.com/4896363/54052731-72273880-41e5-11e9-82a4-c79dbc428a53.png)

![image](https://user-images.githubusercontent.com/4896363/54053100-87509700-41e6-11e9-9dd5-6ef1d2334070.png)

![image](https://user-images.githubusercontent.com/4896363/54053353-3db47c00-41e7-11e9-9139-f25e7e2bf4a6.png)


And also simple type mapping for standard Console helpers:

![image](https://user-images.githubusercontent.com/4896363/54053151-acdda080-41e6-11e9-9439-6c11d05a454e.png)
