### PR TITLE
Bundle Doctrine meta files for expectedArguments/ReturnValues completion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/main/resources/symfony-meta"]
 	path = src/main/resources/symfony-meta
 	url = https://github.com/King2500/symfony-meta.git
+[submodule "src/main/resources/doctrine-meta"]
+	path = src/main/resources/doctrine-meta
+	url = https://github.com/King2500/doctrine-phpstorm-meta.git

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,6 +121,7 @@
         <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectManagerFindTypeProvider"/>
         <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.assistant.signature.MethodSignatureTypeProvider"/>
         <libraryRoot id="symfony_meta" path="/symfony-meta/" runtime="false"/>
+        <libraryRoot id="doctrine_meta" path="/doctrine-meta/" runtime="false"/>
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
Similar to Symfony meta files I wrote them for Doctrine ORM and DBAL (and related stuff).

Since there is no dedicated Doctrine plugin atm and this plugin already has Doctrine completion stuff it made most sense for me to bundle meta files here as well.

This mainly adds completion for types, modes and hint constants in Query, Querybuilders, etc methods.

There is also a neat trick involved, when you write `$qb->where(` it suggests `$qb->expr()` thanks to PhpStorm's matching between `expectedReturnValues` and `expectedArguments` of methods. This makes writing QueryBuilder calls with complex expressions/conditions a lot easier :)

Some things like constant completion in array parameters are not yet possible because Jetbrains has to implement that first. (For example Types mapping for parameters in `fetchAssoc` etc)