### PR TITLE
Services with tag twig.extension should implement Twig_ExtensionInterface

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/dict/ServiceUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/dict/ServiceUtil.java
@@ -87,7 +87,7 @@ public class ServiceUtil {
         put("translation.loader", "\\Symfony\\Component\\Translation\\Loader\\LoaderInterface");
         put("translation.extractor", "\\Symfony\\Component\\Translation\\Extractor\\ExtractorInterface");
         put("translation.dumper", "\\Symfony\\Component\\Translation\\Dumper\\DumperInterface");
-        put("twig.extension", "\\Twig_Extension");
+        put("twig.extension", "\\Twig_ExtensionInterface");
         put("twig.loader", "\\Twig_LoaderInterface");
         put("validator.constraint_validator", "Symfony\\Component\\Validator\\ConstraintValidator");
         put("validator.initializer", "Symfony\\Component\\Validator\\ObjectInitializerInterface");

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInspection/service/TaggedExtendsInterfaceClassInspectionTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInspection/service/TaggedExtendsInterfaceClassInspectionTest.java
@@ -27,7 +27,7 @@ public class TaggedExtendsInterfaceClassInspectionTest extends SymfonyLightCodeI
             "        class: Tag\\Instance<caret>Check\\EmptyClass\n" +
             "        tags:\n" +
             "            -  { name: twig.extension }",
-            "Class needs to implement '\\Twig_Extension' for tag 'twig.extension'"
+            "Class needs to implement '\\Twig_ExtensionInterface' for tag 'twig.extension'"
         );
     }
 


### PR DESCRIPTION
Context: Twig >= 1.38.0 or >= 2.7.0

Before:
- Twig_Extension aliased to Twig\Extension\AbstractExtension

After:
- Twig\Extension\AbstractExtension aliased to Twig_Extension

But we cannot just check for Twig\Extension\AbstractExtension instead of \Twig_Extension because users with old Twig version don't have this class.

So, we check with the interface \Twig_ExtensionInterface because it exists since 1.0.0 and 2.0.0 and works with >= 1.38.0 and >= 2.7.0 because \Twig\Extension\ExtensionInterface is aliased to  \Twig_ExtensionInterface


![image](https://user-images.githubusercontent.com/1501825/54940449-06ee9d80-4f2b-11e9-9f36-ebdcbf758433.png)
![image](https://user-images.githubusercontent.com/1501825/54940534-2e456a80-4f2b-11e9-889e-c7b835c67cda.png)
