### PR TITLE
Add Symfony plugin SVG icons

### DIFF
--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   width="80"
+   height="80"
+   viewBox="0 0 79.999998 80"
+   enable-background="new 0 0 289.333 122.833"
+   xml:space="preserve"
+   id="svg3785"
+   sodipodi:docname="pluginIcon.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   id="metadata3791"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs3789" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1017"
+   id="namedview3787"
+   showgrid="false"
+   inkscape:zoom="6.1002373"
+   inkscape:cx="40.162372"
+   inkscape:cy="63.383637"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="carré" />
+<g
+   id="fond"
+   transform="translate(0,-42.833)">
+</g>
+<g
+   id="compacte"
+   transform="translate(0,-42.833)">
+</g>
+<g
+   id="rectangle"
+   transform="translate(0,-42.833)">
+</g>
+<g
+   id="carré"
+   transform="translate(0,-42.833)">
+	
+	<g
+   id="g3782"
+   transform="matrix(1.4249074,0,0,1.4249074,-43.580794,0.08862647)">
+		<g
+   id="g3762">
+			<circle
+   cx="58.657001"
+   cy="58.07"
+   r="28.072001"
+   id="circle3758" />
+			<path
+   d="m 70.93,40.385 c -2.851,0.1 -5.342,1.672 -7.193,3.846 -2.053,2.384 -3.417,5.213 -4.401,8.099 -1.759,-1.442 -3.116,-3.308 -5.938,-4.122 -2.183,-0.627 -4.473,-0.369 -6.58,1.201 -0.999,0.746 -1.686,1.873 -2.013,2.932 -0.848,2.754 0.889,5.205 1.679,6.086 l 1.725,1.846 c 0.356,0.363 1.211,1.309 0.794,2.664 -0.453,1.475 -2.229,2.428 -4.052,1.867 -0.814,-0.252 -1.984,-0.857 -1.721,-1.709 0.108,-0.35 0.358,-0.613 0.493,-0.912 0.123,-0.26 0.181,-0.454 0.218,-0.568 0.333,-1.088 -0.122,-2.502 -1.286,-2.861 -1.087,-0.332 -2.197,-0.068 -2.628,1.329 -0.49,1.591 0.271,4.472 4.344,5.729 4.772,1.467 8.809,-1.133 9.381,-4.521 0.361,-2.122 -0.599,-3.7 -2.354,-5.729 l -1.43,-1.581 c -0.867,-0.867 -1.164,-2.342 -0.268,-3.475 0.757,-0.957 1.834,-1.365 3.601,-0.886 2.577,0.698 3.726,2.487 5.642,3.93 -0.791,2.595 -1.309,5.2 -1.776,7.538 l -0.287,1.74 c -1.371,7.186 -2.416,11.131 -5.134,13.396 -0.547,0.391 -1.331,0.973 -2.51,1.014 -0.619,0.02 -0.818,-0.406 -0.828,-0.592 -0.014,-0.434 0.353,-0.633 0.596,-0.828 0.363,-0.199 0.912,-0.527 0.875,-1.578 -0.041,-1.246 -1.071,-2.324 -2.559,-2.273 -1.117,0.037 -2.816,1.086 -2.752,3.01 0.066,1.984 1.916,3.473 4.706,3.377 1.492,-0.049 4.822,-0.656 8.103,-4.557 3.819,-4.473 4.888,-9.6 5.692,-13.352 l 0.896,-4.953 c 0.499,0.059 1.031,0.1 1.611,0.113 4.757,0.102 7.136,-2.363 7.173,-4.155 0.023,-1.085 -0.712,-2.152 -1.742,-2.128 -0.736,0.021 -1.662,0.511 -1.884,1.529 -0.217,1 1.514,1.902 0.161,2.779 -0.961,0.623 -2.684,1.061 -5.11,0.705 l 0.442,-2.439 c 0.899,-4.624 2.011,-10.312 6.224,-10.449 0.307,-0.016 1.431,0.014 1.457,0.756 0.007,0.248 -0.054,0.312 -0.344,0.88 -0.297,0.442 -0.408,0.819 -0.395,1.253 0.042,1.18 0.939,1.956 2.238,1.91 1.737,-0.057 2.237,-1.748 2.209,-2.618 -0.072,-2.045 -2.226,-3.335 -5.075,-3.243 z"
+   id="path3760"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+		</g>
+		
+	</g>
+</g>
+</svg>

--- a/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   width="80"
+   height="80"
+   viewBox="0 0 79.999998 80"
+   enable-background="new 0 0 289.333 122.833"
+   xml:space="preserve"
+   id="svg3857"
+   sodipodi:docname="pluginIcon_dark.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"><metadata
+   id="metadata3863"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs3861">
+	
+</defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1017"
+   id="namedview3859"
+   showgrid="false"
+   inkscape:zoom="3.4214883"
+   inkscape:cx="113.97872"
+   inkscape:cy="62.512039"
+   inkscape:window-x="-8"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg3857" />
+
+<g
+   id="g3852"
+   transform="matrix(1.4398589,0,0,1.4398589,-46.363456,-44.111517)">
+		<path
+   style="fill:#ffffff"
+   inkscape:connector-curvature="0"
+   id="path3832"
+   d="m 59.979,30.636 c -15.341,0 -27.779,12.436 -27.779,27.778 0,15.344 12.438,27.783 27.779,27.783 15.344,0 27.782,-12.439 27.782,-27.783 C 87.76,43.071 75.322,30.636 59.979,30.636 Z M 74.96,46.713 c -1.286,0.045 -2.173,-0.722 -2.215,-1.891 -0.013,-0.429 0.097,-0.803 0.391,-1.24 0.287,-0.561 0.348,-0.625 0.34,-0.87 -0.025,-0.735 -1.136,-0.764 -1.44,-0.749 -4.17,0.137 -5.269,5.766 -6.16,10.342 l -0.437,2.413 c 2.401,0.352 4.106,-0.082 5.057,-0.697 1.339,-0.868 -0.374,-1.761 -0.159,-2.75 0.22,-1.008 1.136,-1.493 1.865,-1.514 1.019,-0.024 1.747,1.032 1.724,2.105 -0.037,1.773 -2.392,4.212 -7.099,4.113 -0.574,-0.014 -1.102,-0.054 -1.594,-0.113 l -0.888,4.903 c -0.796,3.713 -1.853,8.786 -5.632,13.212 -3.248,3.86 -6.542,4.46 -8.019,4.51 -2.76,0.093 -4.591,-1.378 -4.657,-3.343 -0.065,-1.902 1.618,-2.942 2.723,-2.979 1.474,-0.05 2.493,1.018 2.532,2.249 0.037,1.041 -0.506,1.366 -0.865,1.563 -0.241,0.192 -0.603,0.39 -0.589,0.82 0.009,0.183 0.208,0.604 0.819,0.584 1.168,-0.039 1.942,-0.616 2.484,-1.002 2.689,-2.241 3.725,-6.147 5.08,-13.257 l 0.284,-1.724 c 0.462,-2.313 0.975,-4.891 1.757,-7.459 -1.897,-1.427 -3.033,-3.197 -5.582,-3.888 -1.748,-0.475 -2.814,-0.072 -3.563,0.875 -0.887,1.122 -0.592,2.582 0.266,3.439 l 1.415,1.564 c 1.736,2.008 2.686,3.568 2.329,5.669 -0.565,3.353 -4.562,5.924 -9.283,4.473 -4.031,-1.242 -4.785,-4.097 -4.301,-5.669 0.427,-1.384 1.526,-1.645 2.602,-1.314 1.151,0.354 1.602,1.753 1.272,2.83 -0.037,0.113 -0.096,0.306 -0.217,0.563 -0.133,0.297 -0.38,0.556 -0.488,0.903 -0.259,0.843 0.898,1.442 1.705,1.69 1.802,0.554 3.561,-0.389 4.008,-1.848 0.415,-1.342 -0.434,-2.277 -0.786,-2.637 l -1.706,-1.828 c -0.782,-0.871 -2.501,-3.296 -1.662,-6.021 0.322,-1.049 1.002,-2.165 1.991,-2.901 2.085,-1.554 4.352,-1.81 6.511,-1.19 2.794,0.806 4.137,2.653 5.878,4.08 0.973,-2.857 2.323,-5.655 4.354,-8.014 1.833,-2.152 4.297,-3.708 7.12,-3.805 2.82,-0.092 4.951,1.185 5.022,3.208 0.028,0.864 -0.468,2.539 -2.187,2.595 z" />
+		
+	</g>
+<g
+   id="rectangle"
+   transform="translate(0,-42.833)">
+</g>
+<g
+   id="carré"
+   transform="translate(0,-42.833)">
+</g>
+</svg>


### PR DESCRIPTION
This adds Symfony icons to plugin (supported by IDEA platform since 2019.1).
(see details here: https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_icon_file.html)

Icons will be shown in Settings > Plugins UI (see Screenshots below) and also in [Plugins Repository](https://plugins.jetbrains.com/).

When using light themes:
![image](https://user-images.githubusercontent.com/4896363/55661947-8c1d6080-580f-11e9-9d01-d4cf8bbd04df.png)

When using Darcula theme:
![image](https://user-images.githubusercontent.com/4896363/55661950-96d7f580-580f-11e9-9075-e5d3e63b6434.png)
