### PR TITLE
Fixed Symfony installer download to use https

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/installer/SymfonyInstallerUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/installer/SymfonyInstallerUtil.java
@@ -35,7 +35,7 @@ public class SymfonyInstallerUtil {
     @Nullable
     public static VirtualFile downloadPhar(@Nullable Project project, JComponent component, @Nullable String toDir)
     {
-        return PhpConfigurationUtil.downloadFile(project, component, toDir, "http://symfony.com/installer", "symfony.phar");
+        return PhpConfigurationUtil.downloadFile(project, component, toDir, "https://symfony.com/installer", "symfony.phar");
     }
 
     @Nullable


### PR DESCRIPTION
I don't know if this is the case but `downloadFile` needs to follow redirect for this to work.