### PR TITLE
added support for constants as FormOption

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/PhpElementsUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/PhpElementsUtil.java
@@ -20,6 +20,9 @@ import com.jetbrains.php.lang.psi.PhpFile;
 import com.jetbrains.php.lang.psi.PhpPsiElementFactory;
 import com.jetbrains.php.lang.psi.PhpPsiUtil;
 import com.jetbrains.php.lang.psi.elements.*;
+import com.jetbrains.php.lang.psi.elements.impl.ClassConstImpl;
+import com.jetbrains.php.lang.psi.elements.impl.ConstantImpl;
+import com.jetbrains.php.lang.psi.elements.impl.PhpDefineImpl;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.phpunit.PhpUnitUtil;
 import com.jetbrains.php.refactoring.PhpAliasImporter;
@@ -58,6 +61,30 @@ public class PhpElementsUtil {
             PhpPsiElement child = arrayHashElement.getKey();
             if(child instanceof StringLiteralExpression) {
                 keys.put(((StringLiteralExpression) child).getContents(), child);
+            }
+            if(child instanceof ClassConstantReference) {
+                PsiElement val = ((ClassConstantReference) child).resolve();
+                if (val instanceof ClassConstImpl) {
+                    PsiElement value = ((ClassConstImpl) val).getDefaultValue();
+                    if (value != null && value.getText() != null) {
+                        keys.put(value.getText().replace("\"", "").replace("\'", ""), child);
+                    }
+                }
+            }
+            if(child instanceof ConstantReference) {
+                PsiElement val = ((ConstantReference) child).resolve();
+                if(val instanceof PhpDefine) {
+                    PhpPsiElement value = ((PhpDefineImpl) val).getValue();
+                    if (value != null) {
+                        keys.put(value.getText().replace("\"", "").replace("\'", ""), child);
+                    }
+                }
+                if(val instanceof ConstantImpl) {
+                    PsiElement value = ((ConstantImpl) val).getValue();
+                    if (value != null && value.getText() != null) {
+                        keys.put(value.getText().replace("\"", "").replace("\'", ""), child);
+                    }
+                }
             }
         }
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/form/FormOptionGotoCompletionRegistrarTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/form/FormOptionGotoCompletionRegistrarTest.java
@@ -36,7 +36,7 @@ public class FormOptionGotoCompletionRegistrarTest extends SymfonyLightCodeInsig
                     String.format("$builder->add('foo', %s, [\n", s) +
                     "'<caret>'\n" +
                     "])",
-                "configure_options"
+                "configure_options", "class_const_option", "global_const_option", "global_const_define"
             );
 
             assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
@@ -44,7 +44,7 @@ public class FormOptionGotoCompletionRegistrarTest extends SymfonyLightCodeInsig
                     String.format("$builder->add('foo', %s, [\n", s) +
                     "'<caret>' => ''\n" +
                     "])",
-                "configure_options"
+                "configure_options", "class_const_option", "global_const_option", "global_const_define"
             );
 
             assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/form/fixtures/FormOptionGotoCompletionRegistrar.php
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/form/fixtures/FormOptionGotoCompletionRegistrar.php
@@ -1,11 +1,17 @@
 <?php
-
+const GLOBAL_CONST_OPTION = 'global_const_option';
+define('GLOBAL_CONST_DEFINE', 'global_const_define');
 namespace Foo\Form {
+
     class Bar {
+        const CLASS_CONST_OPTION = 'class_const_option';
         public function configureOptions($resolver)
         {
             $resolver->setDefaults([
                 'configure_options' => null,
+                self::CLASS_CONST_OPTION => null,
+                GLOBAL_CONST_OPTION => null,
+                GLOBAL_CONST_DEFINE => null,
             ]);
         }
 


### PR DESCRIPTION
Using constants for options of form extensions is very common. This will add support of any type of constants to form options auto completion