### PR TITLE
Fixed typo/wrong YAML service attribute for autowiring_types

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlCompletionContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlCompletionContributor.java
@@ -80,7 +80,7 @@ public class YamlCompletionContributor extends CompletionContributor {
         put("factory_service", "<= 2.5");
         put("factory_method", "<= 2.5");
         put("autowire", "(bool) >= 2.8");
-        put("autowiring_type", ">= 2.8");
+        put("autowiring_types", ">= 2.8, < 4.0");
         put("deprecated", "(string) >= 2.8");
         put("decorates", null);
         put("decoration_inner_name", null);


### PR DESCRIPTION
Instead of `autowiring_type` it should be called `autowiring_types` 
see https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php#L60

Also `autowiring_types` is removed in Symfony 4.0, so I added this note in type text.
see https://github.com/symfony/symfony/pull/22773