### PR TITLE
Overwrite XML injection with plain text for Console output methods 

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/lang/ParameterLanguageInjector.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/lang/ParameterLanguageInjector.java
@@ -43,6 +43,8 @@ public class ParameterLanguageInjector implements MultiHostInjector {
     private static final MethodMatcher.CallToSignature[] RESET_INJECTION_SIGNATURES = {
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Output\\OutputInterface", "write"),
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Output\\OutputInterface", "writeln"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Output\\Output", "write"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Output\\Output", "writeln"),
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Formatter\\OutputFormatter", "escape"),
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Formatter\\OutputFormatter", "escapeTrailingBackslash"),
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Formatter\\OutputFormatterInterface", "format"),

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/lang/ParameterLanguageInjector.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/lang/ParameterLanguageInjector.java
@@ -40,17 +40,27 @@ public class ParameterLanguageInjector implements MultiHostInjector {
             new MethodMatcher.CallToSignature("\\Doctrine\\ORM\\Query", "setDQL"),
     };
 
+    private static final MethodMatcher.CallToSignature[] RESET_INJECTION_SIGNATURES = {
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Output\\OutputInterface", "write"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Output\\OutputInterface", "writeln"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Formatter\\OutputFormatter", "escape"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Formatter\\OutputFormatter", "escapeTrailingBackslash"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Component\\Console\\Formatter\\OutputFormatterInterface", "format"),
+    };
+
     private final MethodLanguageInjection[] LANGUAGE_INJECTIONS = {
             new MethodLanguageInjection(LANGUAGE_ID_CSS, "@media all { ", " }", CSS_SELECTOR_SIGNATURES),
             new MethodLanguageInjection(LANGUAGE_ID_XPATH, null, null, XPATH_SIGNATURES),
             new MethodLanguageInjection(LANGUAGE_ID_JSON, null, null, JSON_SIGNATURES),
             new MethodLanguageInjection(LANGUAGE_ID_DQL, null, null, DQL_SIGNATURES),
+            new MethodLanguageInjection(LANGUAGE_ID_TEXT, null, null, RESET_INJECTION_SIGNATURES),
     };
 
     public static final String LANGUAGE_ID_CSS = "CSS";
     public static final String LANGUAGE_ID_XPATH = "XPath";
     public static final String LANGUAGE_ID_JSON = "JSON";
     public static final String LANGUAGE_ID_DQL = "DQL";
+    public static final String LANGUAGE_ID_TEXT = "TEXT";
 
     private static final String DQL_VARIABLE_NAME = "dql";
 
@@ -97,6 +107,10 @@ public class ParameterLanguageInjector implements MultiHostInjector {
             // JsonResponse::fromJsonString('...')
             if (parent instanceof MethodReference) {
                 if (PhpElementsUtil.isMethodReferenceInstanceOf((MethodReference) parent, languageInjection.getSignatures())) {
+                    // Only "overwrite" language injection to "TEXT" when XML-like characters in literal
+                    if (LANGUAGE_ID_TEXT.equals(language.getID()) && !expr.getContents().contains("<")) {
+                        return;
+                    }
                     injectLanguage(registrar, expr, language, languageInjection);
                     return;
                 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -239,7 +239,7 @@
         <codeInsight.parameterNameHints language="XML" implementationClass="fr.adrienbrault.idea.symfony2plugin.dic.ServiceArgumentParameterHintsProvider"/>
         <codeInsight.parameterNameHints language="yaml" implementationClass="fr.adrienbrault.idea.symfony2plugin.dic.ServiceArgumentParameterHintsProvider"/>
 
-        <multiHostInjector implementation="fr.adrienbrault.idea.symfony2plugin.lang.ParameterLanguageInjector"/>
+        <multiHostInjector implementation="fr.adrienbrault.idea.symfony2plugin.lang.ParameterLanguageInjector" order="first"/>
 
         <localInspection groupPath="Symfony" shortName="PhpRouteMissingInspection" displayName="Route Missing"
                          groupName="Route"

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/lang/ParameterLanguageInjectorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/lang/ParameterLanguageInjectorTest.java
@@ -69,6 +69,16 @@ public class ParameterLanguageInjectorTest extends SymfonyLightCodeInsightFixtur
         assertInjectedLangAtCaret(PhpFileType.INSTANCE, "<?php $dql = \"<caret>\");", LANGUAGE_ID_DQL);
     }
 
+    public void testTextLanguageInjections() {
+        String base = "<?php $output = new \\Symfony\\Component\\Console\\Output\\Output();\n";
+        assertInjectedLangAtCaret(PhpFileType.INSTANCE, base + "$output->write('<info>foo<caret></info>');", LANGUAGE_ID_TEXT);
+
+        String base2 = "<?php /** @var $output \\Symfony\\Component\\Console\\Output\\OutputInterface */\n";
+        assertInjectedLangAtCaret(PhpFileType.INSTANCE, base2 + "$output->writeln('<info>foo<caret></info>');", LANGUAGE_ID_TEXT);
+
+        assertInjectedLangAtCaret(PhpFileType.INSTANCE, "\\Symfony\\Component\\Console\\Formatter\\OutputFormatter::escape('<info>foo<caret></info>');", LANGUAGE_ID_TEXT);
+    }
+
     private void assertInjectedLangAtCaret(LanguageFileType fileType, String configureByText, String lang) {
         myFixture.configureByText(fileType, configureByText);
         injectionTestFixture.assertInjectedLangAtCaret(lang);


### PR DESCRIPTION
This solves #1352 by overwriting with plain TEXT injection (only if `<` char appears in string literal).

![image](https://user-images.githubusercontent.com/4896363/62562287-1ab6f280-b881-11e9-881e-697c36d40bc8.png)

I have not found any other solution yet, which would "remove" the existing (automatic) XML injection.