### PR TITLE
added path for default container in Symfony 4

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/Settings.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/Settings.java
@@ -29,6 +29,7 @@ public class Settings implements PersistentStateComponent<Settings> {
         "app/cache/dev/appDevDebugProjectContainer.xml",
         "var/cache/dev/appDevDebugProjectContainer.xml",
         "var/cache/dev/srcDevDebugProjectContainer.xml",
+        "var/cache/dev/srcApp_KernelDevDebugContainer.xml",
     };
 
     // Default Symfony 2, 3 and 4 paths


### PR DESCRIPTION

Fixes #1295 
By default, Symfony 4 generate application containers based on Kernel properties.

Method `Symfony\Component\HttpKernel\Kernel@initializeContainer()` use `Symfony\Component\HttpKernel\Kernel@getContainerClass()` to build file name for container based on following Kernel class properties:
- `$name` – base dir for Kernel class (src)
- `$class` – FQN for Kernel class, backslash replaced with underscore (App\Kernel > App_Kernel)
- `$environment` – configured environment, based on APP_ENV (Dev, Test, Prod, etc.)
- `$debug` – debug mode, adds **Debug** to file name, based on APP_DEBUG ("Debug" or empty string)

All these variables prepended to base name "Container".

So, default container filename for DEV environment with Debug enabled will always:
src + App_Kernel +Dev + Debug + Container -> srcApp_KernelDevDebugContainer

Tested on PhpStorm 2019.2.1 with Symfony 4.3 (both on Full Stack Framework and Microservices  versions)