### PR TITLE
Added support for namespaced Twig classes

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/SymfonyPhpReferenceContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/SymfonyPhpReferenceContributor.java
@@ -75,6 +75,14 @@ public class SymfonyPhpReferenceContributor extends PsiReferenceContributor {
         new MethodMatcher.CallToSignature("\\Twig_Environment", "display"),
         new MethodMatcher.CallToSignature("\\Twig_Environment", "isTemplateFresh"),
         new MethodMatcher.CallToSignature("\\Twig_Environment", "resolveTemplate"), // @TODO: also "is_array($names)"
+
+        new MethodMatcher.CallToSignature("\\Twig\\Environment", "render"),
+        new MethodMatcher.CallToSignature("\\Twig\\Environment", "load"),
+        new MethodMatcher.CallToSignature("\\Twig\\Environment", "loadTemplate"),
+        new MethodMatcher.CallToSignature("\\Twig\\Environment", "getTemplateClass"),
+        new MethodMatcher.CallToSignature("\\Twig\\Environment", "display"),
+        new MethodMatcher.CallToSignature("\\Twig\\Environment", "isTemplateFresh"),
+        new MethodMatcher.CallToSignature("\\Twig\\Environment", "resolveTemplate"), // @TODO: also "is_array($names)"
     };
 
     @Override


### PR DESCRIPTION
Fixes not being able to follow template references with another extension than `*.twig` in `loadTemplate()` and `load()` calls with Twig version 1.38 and higher.