### PR TITLE
Add support for autocompletion inside the MessageSubscriberInterface::getHandledMessages method

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/php/PhpMessageSubscriberGotoCompletionRegistrar.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/php/PhpMessageSubscriberGotoCompletionRegistrar.java
@@ -1,0 +1,158 @@
+package fr.adrienbrault.idea.symfony2plugin.config.php;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.patterns.PatternCondition;
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.PsiElementPattern;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.ProcessingContext;
+import com.jetbrains.php.lang.PhpLanguage;
+import com.jetbrains.php.lang.parser.PhpElementTypes;
+import com.jetbrains.php.lang.psi.elements.*;
+import fr.adrienbrault.idea.symfony2plugin.codeInsight.GotoCompletionProvider;
+import fr.adrienbrault.idea.symfony2plugin.codeInsight.GotoCompletionRegistrar;
+import fr.adrienbrault.idea.symfony2plugin.codeInsight.GotoCompletionRegistrarParameter;
+import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * \Symfony\Component\Messenger\Handler\MessageSubscriberInterface::getHandledMessages
+ *
+ * yield FirstMessage::class => ['method' => '<caret>']
+ *
+ * return array(
+ *   FirstMessage::class => '<caret>',
+ * )
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+public class PhpMessageSubscriberGotoCompletionRegistrar implements GotoCompletionRegistrar {
+    private static PsiElementPattern.Capture<PsiElement> REGISTRAR_PATTERN = PlatformPatterns.psiElement()
+        .withLanguage(PhpLanguage.INSTANCE)
+        .withParent(
+            PlatformPatterns.psiElement(StringLiteralExpression.class).withParent(
+                PlatformPatterns.psiElement()
+                    .withElementType(PhpElementTypes.ARRAY_VALUE)
+                    .withParent(
+                        PlatformPatterns.or(
+                            PlatformPatterns.psiElement(ArrayHashElement.class)
+                                .withParent(PlatformPatterns.psiElement(ArrayCreationExpression.class).withParent(PhpReturn.class))
+                                .with(new PatternCondition<ArrayHashElement>("Key Type") {
+                                    @Override
+                                    public boolean accepts(@NotNull ArrayHashElement arrayHashElement, ProcessingContext context) {
+                                        PhpPsiElement keyElement = arrayHashElement.getKey();
+
+                                        return keyElement instanceof StringLiteralExpression || keyElement instanceof ClassConstantReference;
+                                    }
+                                }),
+                            PlatformPatterns.psiElement(ArrayHashElement.class)
+                                .with(new PatternCondition<ArrayHashElement>("Key Text") {
+                                    @Override
+                                    public boolean accepts(@NotNull ArrayHashElement arrayHashElement, ProcessingContext context) {
+                                        PhpPsiElement keyElement = arrayHashElement.getKey();
+
+                                        if (!(keyElement instanceof StringLiteralExpression)) {
+                                            return false;
+                                        }
+
+                                        return ((StringLiteralExpression) keyElement).getContents().equals("method");
+                                    }
+                                })
+                                .withParent(
+                                    PlatformPatterns.psiElement(ArrayCreationExpression.class).withParent(
+                                        PlatformPatterns.psiElement(PhpYield.class)
+                                            .with(new PatternCondition<PhpYield>("Yield Key Type") {
+                                                @Override
+                                                public boolean accepts(@NotNull PhpYield phpYield, ProcessingContext context) {
+                                                    PsiElement keyElement = phpYield.getArgument();
+
+                                                    return keyElement instanceof StringLiteralExpression || keyElement instanceof ClassConstantReference;
+                                                }
+                                            })
+                                    )
+                                )
+                        )
+                    )
+            )
+        );
+
+    @Override
+    public void register(@NotNull GotoCompletionRegistrarParameter registrar) {
+        registrar.register(REGISTRAR_PATTERN, psiElement -> {
+            Method method = PsiTreeUtil.getParentOfType(psiElement, Method.class, true, Function.class);
+
+            if (method == null) {
+                return null;
+            }
+
+            if (!PhpElementsUtil.isMethodInstanceOf(method, "\\Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface", "getHandledMessages")) {
+                return null;
+            }
+
+            return new PhpClassPublicMethodProvider(method.getContainingClass());
+        });
+    }
+
+    private static class PhpClassPublicMethodProvider extends GotoCompletionProvider {
+        private final PhpClass phpClass;
+
+        public PhpClassPublicMethodProvider(@NotNull PhpClass phpClass) {
+            super(phpClass);
+
+            this.phpClass = phpClass;
+        }
+
+        @NotNull
+        @Override
+        public Collection<LookupElement> getLookupElements() {
+            Collection<LookupElement> elements = new ArrayList<>();
+
+            for (Method method : phpClass.getMethods()) {
+                if (!method.getAccess().isPublic()) {
+                    continue;
+                }
+
+                String methodName = method.getName();
+
+                if (methodName.equals("getHandledMessages") || methodName.startsWith("__")) {
+                    continue;
+                }
+
+                elements.add(LookupElementBuilder.createWithIcon(method));
+            }
+
+            return elements;
+        }
+
+        @NotNull
+        @Override
+        public Collection<PsiElement> getPsiTargets(PsiElement element) {
+            PsiElement parentElement = element.getParent();
+
+            if (!(parentElement instanceof StringLiteralExpression)) {
+                return Collections.emptyList();
+            }
+
+            String contents = ((StringLiteralExpression) parentElement).getContents();
+
+            if (StringUtils.isBlank(contents)) {
+                return Collections.emptyList();
+            }
+
+            Method method = phpClass.findMethodByName(contents);
+
+            if (method != null) {
+                return Collections.singletonList(method);
+            }
+
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -559,6 +559,7 @@
         <GotoCompletionRegistrar implementation="fr.adrienbrault.idea.symfony2plugin.templating.TranslationTagGotoCompletionRegistrar"/>
         <GotoCompletionRegistrar implementation="fr.adrienbrault.idea.symfony2plugin.form.FormGotoCompletionRegistrar"/>
         <GotoCompletionRegistrar implementation="fr.adrienbrault.idea.symfony2plugin.config.php.PhpEventDispatcherGotoCompletionRegistrar"/>
+        <GotoCompletionRegistrar implementation="fr.adrienbrault.idea.symfony2plugin.config.php.PhpMessageSubscriberGotoCompletionRegistrar"/>
         <GotoCompletionRegistrar implementation="fr.adrienbrault.idea.symfony2plugin.completion.command.PhpCommandGotoCompletionRegistrar"/>
         <GotoCompletionRegistrar implementation="fr.adrienbrault.idea.symfony2plugin.completion.command.ConsoleHelperGotoCompletionRegistrar"/>
         <GotoCompletionRegistrar implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.metadata.DoctrineXmlGotoCompletionRegistrar"/>

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/SymfonyLightCodeInsightFixtureTestCase.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/SymfonyLightCodeInsightFixtureTestCase.java
@@ -103,6 +103,22 @@ public abstract class SymfonyLightCodeInsightFixtureTestCase extends LightCodeIn
         completionContainsAssert(lookupStrings);
     }
 
+    public void assertCompletionIsEmpty(LanguageFileType languageFileType, String configureByText) {
+
+        myFixture.configureByText(languageFileType, configureByText);
+        myFixture.completeBasic();
+
+        List<String> lookupElements = myFixture.getLookupElementStrings();
+
+        if (lookupElements == null) {
+            return;
+        }
+
+        if (!lookupElements.isEmpty()) {
+            fail("Failed that completion is empty.");
+        }
+    }
+
     private void completionContainsAssert(String[] lookupStrings) {
         if(lookupStrings.length == 0) {
             fail("No lookup element given");

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/php/PhpMessageSubscriberGotoCompletionRegistrarTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/php/PhpMessageSubscriberGotoCompletionRegistrarTest.java
@@ -1,0 +1,186 @@
+package fr.adrienbrault.idea.symfony2plugin.tests.config.php;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.jetbrains.php.lang.PhpFileType;
+import com.jetbrains.php.lang.psi.elements.Method;
+import com.jetbrains.php.lang.psi.elements.PhpClass;
+import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ *
+ * @see fr.adrienbrault.idea.symfony2plugin.config.php.PhpMessageSubscriberGotoCompletionRegistrar
+ */
+public class PhpMessageSubscriberGotoCompletionRegistrarTest extends SymfonyLightCodeInsightFixtureTestCase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        myFixture.copyFileToProject("classes.php");
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/php/fixtures";
+    }
+
+    public void testAutocompletionForGetHandledMessagesMethodOfMessageSubscriberInterface() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+            "final class FooMessageSubscriber implements Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface\n" +
+            "{\n" +
+            "    public function handleFooEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function handleBarEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    private function handleBazEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    protected function handleQuxEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function __toString(): string\n" +
+            "    {\n" +
+            "        return '';\n" +
+            "    }\n" +
+            "    public function getHandledMessages(): iterable\n" +
+            "    {\n" +
+            "        yield FooEvent::class => ['method' => '<caret>'];\n" +
+            "    }\n" +
+            "}",
+            "handleFooEvent",
+            "handleBarEvent"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+            "final class FooMessageSubscriber implements Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface\n" +
+            "{\n" +
+            "    public function handleFooEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function getHandledMessages(): iterable\n" +
+            "    {\n" +
+            "        yield FooEvent::class => ['method' => '<caret>handleFooEvent'];\n" +
+            "    }\n" +
+            "}",
+            PlatformPatterns.psiElement(Method.class).withName("handleFooEvent")
+        );
+
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+            "final class FooMessageSubscriber implements Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface\n" +
+            "{\n" +
+            "    public function handleFooEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function handleBarEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    private function handleBazEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    protected function handleQuxEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function __toString(): string\n" +
+            "    {\n" +
+            "        return '';\n" +
+            "    }\n" +
+            "    public function getHandledMessages(): iterable\n" +
+            "    {\n" +
+            "        yield 'FooEvent' => ['method' => '<caret>'];\n" +
+            "    }\n" +
+            "}",
+            "handleFooEvent",
+            "handleBarEvent"
+        );
+
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+            "final class FooMessageSubscriber implements Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface\n" +
+            "{\n" +
+            "    public function handleFooEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function handleBarEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    private function handleBazEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    protected function handleQuxEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function __toString(): string\n" +
+            "    {\n" +
+            "        return '';\n" +
+            "    }\n" +
+            "    public function getHandledMessages(): iterable\n" +
+            "    {\n" +
+            "        return [FooEvent::class => '<caret>'];\n" +
+            "    }\n" +
+            "}",
+            "handleFooEvent",
+            "handleBarEvent"
+        );
+
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+            "final class FooMessageSubscriber implements Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface\n" +
+            "{\n" +
+            "    public function handleFooEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function handleBarEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    private function handleBazEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    protected function handleQuxEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function __toString(): string\n" +
+            "    {\n" +
+            "        return '';\n" +
+            "    }\n" +
+            "    public function getHandledMessages(): iterable\n" +
+            "    {\n" +
+            "        return ['FooEvent' => '<caret>'];\n" +
+            "    }\n" +
+            "}",
+            "handleFooEvent",
+            "handleBarEvent"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+            "final class FooMessageSubscriber implements Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface\n" +
+            "{\n" +
+            "    public function handleFooEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function getHandledMessages(): iterable\n" +
+            "    {\n" +
+            "        return [FooEvent::class => '<caret>handleFooEvent'];\n" +
+            "    }\n" +
+            "}",
+            PlatformPatterns.psiElement(Method.class).withName("handleFooEvent")
+        );
+
+        assertCompletionIsEmpty(PhpFileType.INSTANCE, "<?php\n" +
+            "final class FooMessageSubscriber implements Symfony\\Component\\Messenger\\Handler\\MessageSubscriberInterface\n" +
+            "{\n" +
+            "    public function handleFooEvent(): void\n" +
+            "    {\n" +
+            "    }\n" +
+            "    public function getHandledMessages(): iterable\n" +
+            "    {\n" +
+            "        $foo = static function (): iterable {" +
+            "            return ['FooEvent' => '<caret>'];\n" +
+            "        };" +
+            "    }\n" +
+            "}"
+        );
+    }
+}

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/php/fixtures/classes.php
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/php/fixtures/classes.php
@@ -17,3 +17,11 @@ namespace Symfony\Component\DependencyInjection
         }
     }
 }
+
+namespace Symfony\Component\Messenger\Handler
+{
+    interface MessageSubscriberInterface
+    {
+        public static function getHandledMessages(): iterable;
+    }
+}


### PR DESCRIPTION
With this PR the autocompletion inside the [`MessageSubscriberInterface::getHandledMessage()`](https://github.com/symfony/symfony/blob/985f64b5af01ab2b54b054ebd8c527dca9fe8e6f/src/Symfony/Component/Messenger/Handler/MessageSubscriberInterface.php) method should work when typing the name of the method that will handle a certain event. The following cases are supported:

```php
public static function getHandledMessages(): iterable
{
    yield FirstMessage::class => [
        'method' => '<caret>',
    ];

    yield 'FirstMessage' => [
        'method' => '<caret>',
    ];

    return [
        FirstMessage::class => '<caret>',
        'FirstMessage' => '<caret>',
    ];
}
```

I tried to restrict the autocompletion so that it works only for the cases described above to avoid suggestions in cases where nothing has to do with them. I'm also not sure that the `src/main/java/fr/adrienbrault/idea/symfony2plugin/config/php/` folder is the right one as it seems more tied with the scope of containing autocompletion for the config files, so let me know if I need to move the class somewhere else