### PR TITLE
Fix doctrine repository find() methods not always returning the correct type hints

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/assistant/signature/MethodSignatureTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/assistant/signature/MethodSignatureTypeProvider.java
@@ -11,6 +11,7 @@ import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider3;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
 import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.extension.MethodSignatureTypeProviderExtension;
 import fr.adrienbrault.idea.symfony2plugin.extension.MethodSignatureTypeProviderParameter;
@@ -27,7 +28,7 @@ import java.util.Set;
  * @author Adrien Brault <adrien.brault@gmail.com>
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-public class MethodSignatureTypeProvider implements PhpTypeProvider3 {
+public class MethodSignatureTypeProvider implements PhpTypeProvider4 {
 
     final static char TRIM_KEY = '\u0181';
     private static final ExtensionPointName<MethodSignatureTypeProviderExtension> EXTENSIONS = new ExtensionPointName<>("fr.adrienbrault.idea.symfony2plugin.extension.MethodSignatureTypeProviderExtension");
@@ -118,6 +119,11 @@ public class MethodSignatureTypeProvider implements PhpTypeProvider3 {
         }
 
         return matchedSignatures;
+    }
+
+    @Override
+    public PhpType complete(String expression, Project project) {
+        return null;
     }
 
     @Override

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/SymfonyContainerTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/SymfonyContainerTypeProvider.java
@@ -9,6 +9,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider3;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
 import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.util.ServiceContainerUtil;
 import fr.adrienbrault.idea.symfony2plugin.stubs.ContainerCollectionResolver;
@@ -24,7 +25,7 @@ import java.util.Set;
  * @author Adrien Brault <adrien.brault@gmail.com>
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-public class SymfonyContainerTypeProvider implements PhpTypeProvider3 {
+public class SymfonyContainerTypeProvider implements PhpTypeProvider4 {
     private static char TRIM_KEY = '\u0182';
 
     @Override
@@ -46,6 +47,11 @@ public class SymfonyContainerTypeProvider implements PhpTypeProvider3 {
 
         String signature = PhpTypeProviderUtil.getReferenceSignatureByFirstParameter((MethodReference) e, TRIM_KEY);
         return signature == null ? null : new PhpType().add("#" + this.getKey() + signature);
+    }
+
+    @Override
+    public PhpType complete(String expression, Project project) {
+        return null;
     }
 
     @Override

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectManagerFindTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectManagerFindTypeProvider.java
@@ -10,6 +10,7 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider3;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
 import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpTypeProviderUtil;
@@ -24,7 +25,7 @@ import java.util.Set;
  *
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-public class ObjectManagerFindTypeProvider implements PhpTypeProvider3 {
+public class ObjectManagerFindTypeProvider implements PhpTypeProvider4 {
 
     final static char TRIM_KEY = '\u0183';
 
@@ -59,6 +60,11 @@ public class ObjectManagerFindTypeProvider implements PhpTypeProvider3 {
             }
         }
 
+        return null;
+    }
+
+    @Override
+    public PhpType complete(String expression, Project project) {
         return null;
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
@@ -10,6 +10,7 @@ import com.jetbrains.php.lang.psi.elements.Method;
 import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import com.jetbrains.php.lang.psi.elements.impl.MethodImpl;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
 import fr.adrienbrault.idea.symfony2plugin.Settings;
@@ -102,15 +103,9 @@ public class ObjectRepositoryResultTypeProvider implements PhpTypeProvider4 {
 
         repositorySignature = repositorySignature.substring(1, nextMethodCall);
 
-        if (repositorySignature.startsWith("#K#C")) {
-            repositorySignature = repositorySignature.substring(4);
-        }
+        String signature = "#" + this.getKey() + refSignature.substring(0, refSignature.indexOf("|")) + TRIM_KEY + repositorySignature;
 
-        if (repositorySignature.contains(".class")) {
-            repositorySignature = repositorySignature.substring(0, repositorySignature.indexOf(".class"));
-        }
-
-        return new PhpType().add("#" + this.getKey() + refSignature + TRIM_KEY + repositorySignature);
+        return new PhpType().add(signature);
     }
 
     @Override
@@ -155,8 +150,10 @@ public class ObjectRepositoryResultTypeProvider implements PhpTypeProvider4 {
 
         String name = method.getName();
         if(name.equals("findAll") || name.equals("findBy")) {
-            method.getType().add(phpClass.getFQN() + "[]");
-            return phpNamedElementCollections;
+            Method m = new MethodImpl(method.getNode());
+            m.getType().add(phpClass.getFQN() + "[]");
+
+            return PhpTypeProviderUtil.mergeSignatureResults(phpNamedElementCollections, m);
         }
 
         return PhpTypeProviderUtil.mergeSignatureResults(phpNamedElementCollections, phpClass);

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
@@ -11,7 +11,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
-import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider3;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
 import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.util.MethodMatcher;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
@@ -26,7 +26,7 @@ import java.util.Set;
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-public class ObjectRepositoryResultTypeProvider implements PhpTypeProvider3 {
+public class ObjectRepositoryResultTypeProvider implements PhpTypeProvider4 {
     private static MethodMatcher.CallToSignature[] FIND_SIGNATURES = new MethodMatcher.CallToSignature[] {
         new MethodMatcher.CallToSignature("\\Doctrine\\Common\\Persistence\\ObjectRepository", "find"),
         new MethodMatcher.CallToSignature("\\Doctrine\\Common\\Persistence\\ObjectRepository", "findOneBy"),
@@ -103,6 +103,11 @@ public class ObjectRepositoryResultTypeProvider implements PhpTypeProvider3 {
         repositorySignature = repositorySignature.substring(1, nextMethodCall);
 
         return new PhpType().add("#" + this.getKey() + refSignature + TRIM_KEY + repositorySignature);
+    }
+
+    @Override
+    public PhpType complete(String expression, Project project) {
+        return null;
     }
 
     @Override

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryResultTypeProvider.java
@@ -102,6 +102,14 @@ public class ObjectRepositoryResultTypeProvider implements PhpTypeProvider4 {
 
         repositorySignature = repositorySignature.substring(1, nextMethodCall);
 
+        if (repositorySignature.startsWith("#K#C")) {
+            repositorySignature = repositorySignature.substring(4);
+        }
+
+        if (repositorySignature.contains(".class")) {
+            repositorySignature = repositorySignature.substring(0, repositorySignature.indexOf(".class"));
+        }
+
         return new PhpType().add("#" + this.getKey() + refSignature + TRIM_KEY + repositorySignature);
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/ObjectRepositoryTypeProvider.java
@@ -9,7 +9,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
-import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider3;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
 import fr.adrienbrault.idea.symfony2plugin.Settings;
 import fr.adrienbrault.idea.symfony2plugin.util.MethodMatcher;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
@@ -23,7 +23,7 @@ import java.util.Set;
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-public class ObjectRepositoryTypeProvider implements PhpTypeProvider3 {
+public class ObjectRepositoryTypeProvider implements PhpTypeProvider4 {
     private static MethodMatcher.CallToSignature[] GET_REPOSITORIES_SIGNATURES = new MethodMatcher.CallToSignature[] {
         new MethodMatcher.CallToSignature("\\Doctrine\\Common\\Persistence\\ManagerRegistry", "getRepository"),
         new MethodMatcher.CallToSignature("\\Doctrine\\Common\\Persistence\\ObjectManager", "getRepository"),
@@ -57,6 +57,11 @@ public class ObjectRepositoryTypeProvider implements PhpTypeProvider3 {
 
         String signature = PhpTypeProviderUtil.getReferenceSignatureByFirstParameter((MethodReference) e, TRIM_KEY);
         return signature == null ? null : new PhpType().add("#" + this.getKey() + signature);
+    }
+
+    @Override
+    public PhpType complete(String expression, Project project) {
+        return null;
     }
 
     @Override

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/EventDispatcherTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/EventDispatcherTypeProvider.java
@@ -6,6 +6,7 @@ import com.jetbrains.php.PhpIndex;
 import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.resolve.types.PhpType;
 import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider3;
+import com.jetbrains.php.lang.psi.resolve.types.PhpTypeProvider4;
 import fr.adrienbrault.idea.symfony2plugin.Settings;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nullable;
@@ -17,7 +18,7 @@ import java.util.Set;
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-public class EventDispatcherTypeProvider implements PhpTypeProvider3 {
+public class EventDispatcherTypeProvider implements PhpTypeProvider4 {
 
     private static char TRIM_KEY = '\u0197';
 
@@ -74,6 +75,11 @@ public class EventDispatcherTypeProvider implements PhpTypeProvider3 {
         }
 
         return new PhpType().add("#" + this.getKey() + refSignature + TRIM_KEY + signature);
+    }
+
+    @Override
+    public PhpType complete(String expression, Project project) {
+        return null;
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -100,12 +100,12 @@
     <idea-version since-build="182.0"/>
 
     <extensions defaultExtensionNs="com.jetbrains.php">
-        <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.dic.SymfonyContainerTypeProvider"/>
-        <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.util.EventDispatcherTypeProvider"/>
-        <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryTypeProvider"/>
-        <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryResultTypeProvider"/>
-        <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectManagerFindTypeProvider"/>
-        <typeProvider3 implementation="fr.adrienbrault.idea.symfony2plugin.assistant.signature.MethodSignatureTypeProvider"/>
+        <typeProvider4 implementation="fr.adrienbrault.idea.symfony2plugin.dic.SymfonyContainerTypeProvider"/>
+        <typeProvider4 implementation="fr.adrienbrault.idea.symfony2plugin.util.EventDispatcherTypeProvider"/>
+        <typeProvider4 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryTypeProvider"/>
+        <typeProvider4 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectRepositoryResultTypeProvider"/>
+        <typeProvider4 implementation="fr.adrienbrault.idea.symfony2plugin.doctrine.ObjectManagerFindTypeProvider"/>
+        <typeProvider4 implementation="fr.adrienbrault.idea.symfony2plugin.assistant.signature.MethodSignatureTypeProvider"/>
         <libraryRoot id="symfony_meta" path="/symfony-meta/" runtime="false"/>
         <libraryRoot id="doctrine_meta" path="/doctrine-meta/" runtime="false"/>
     </extensions>


### PR DESCRIPTION
I'm not entirely sure how these classes/extension points work and I don't normally code in Java let alone IntelliJ plugins - but this seems to be working for me 🤷‍♂ .

It seems like it wasn't resolving class references correctly. Stripping the class identifiers in the signature solves it so the `getSignature()` method can find the PHP class and return it as a type hint. 

Code review would be appreciated as I don't really know what I'm doing 😂 

Potential fix for #1422 
