### PR TITLE
Added reference and inspection support for TranslatorHelper

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
@@ -54,8 +54,8 @@ public class TranslationUtil {
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Translation\\TranslatorInterface", "transChoice"),
         new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "trans"),
         new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "transChoice"),
-        new MethodMatcher.CallToSignature("\\Symfony\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "trans"),
-        new MethodMatcher.CallToSignature("\\Symfony\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "transChoice")
+        new MethodMatcher.CallToSignature("\\Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "trans"),
+        new MethodMatcher.CallToSignature("\\Symfony\\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "transChoice")
     };
 
     private static final String[] XLIFF_XPATH = {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
@@ -53,7 +53,7 @@ public class TranslationUtil {
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Translation\\TranslatorInterface", "trans"),
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Translation\\TranslatorInterface", "transChoice"),
         new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "trans"),
-        new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "transChoice")
+        new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "transChoice"),
         new MethodMatcher.CallToSignature("\\Symfony\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "trans"),
         new MethodMatcher.CallToSignature("\\Symfony\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "transChoice")
     };

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
@@ -54,6 +54,8 @@ public class TranslationUtil {
         new MethodMatcher.CallToSignature("\\Symfony\\Component\\Translation\\TranslatorInterface", "transChoice"),
         new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "trans"),
         new MethodMatcher.CallToSignature("\\Symfony\\Contracts\\Translation\\TranslatorInterface", "transChoice")
+        new MethodMatcher.CallToSignature("\\Symfony\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "trans"),
+        new MethodMatcher.CallToSignature("\\Symfony\Bundle\\FrameworkBundle\\Templating\\Helper\\TranslatorHelper", "transChoice")
     };
 
     private static final String[] XLIFF_XPATH = {


### PR DESCRIPTION
In controller we get completion/reference as well as inspection support for `Translator(Interface)` methods `trans` and `transChoice`.

But if you use the PHP-template helper `$view['translator']` (which is `\Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper` with same method signatures) completion etc is not working:

```php
/** @var \Symfony\Component\Templating\PhpEngine $view */
$view['translator']->trans('<caret>' ...);
```


We have the following mapping in our `.phpstorm.meta.php`, so `$view['translator']` resolves to
`\Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper`:
```php
// $view['arg'] lookups
override(new \Symfony\Component\Templating\PhpEngine,
    map([
        // ...
        'translator' => \Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper::class,
    ])
);
```