### PR TITLE
Fix completion inside Twig for comment defined variables

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/util/TwigTypeResolveUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/util/TwigTypeResolveUtil.java
@@ -69,9 +69,9 @@ public class TwigTypeResolveUtil {
 
     // for supporting completion and navigation of one line element
     public static final String[] DOC_TYPE_PATTERN_SINGLE  = new String[] {
-        "\\{#[\\s]+(?<var>[\\w]+)[\\s]+(?<class>[\\w\\\\\\[\\]]+)[\\s]+#}",
-        "\\{#[\\s]+"+ DOC_TYPE_PATTERN_CLASS_SECOND + "[\\s]+#}",
-        "\\{#[\\s]+"+ DOC_TYPE_PATTERN_CLASS_FIRST + "[\\s]+#}",
+        "(?<var>[\\w]+)[\\s]+(?<class>[\\w\\\\\\[\\]]+)",
+        DOC_TYPE_PATTERN_CLASS_SECOND,
+        DOC_TYPE_PATTERN_CLASS_FIRST,
     };
 
     private static String[] PROPERTY_SHORTCUTS = new String[] {"get", "is", "has"};

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/util/TwigTypeResolveUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/util/TwigTypeResolveUtilTest.java
@@ -54,9 +54,9 @@ public class TwigTypeResolveUtilTest extends SymfonyLightCodeInsightFixtureTestC
     }
 
     public void testReqExForInlineDocVariables() {
-        assertMatches("{# @var foo_1 \\AppBundle\\Entity\\MeterValueDTO #}", TwigTypeResolveUtil.DOC_TYPE_PATTERN_SINGLE);
-        assertMatches("{# @var \\AppBundle\\Entity\\MeterValueDTO foo_1 #}", TwigTypeResolveUtil.DOC_TYPE_PATTERN_SINGLE);
-        assertMatches("{# foo_1 \\AppBundle\\Entity\\MeterValueDTO #}", TwigTypeResolveUtil.DOC_TYPE_PATTERN_SINGLE);
+        assertMatches("@var foo_1 \\AppBundle\\Entity\\MeterValueDTO", TwigTypeResolveUtil.DOC_TYPE_PATTERN_SINGLE);
+        assertMatches("@var \\AppBundle\\Entity\\MeterValueDTO foo_1", TwigTypeResolveUtil.DOC_TYPE_PATTERN_SINGLE);
+        assertMatches("foo_1 \\AppBundle\\Entity\\MeterValueDTO", TwigTypeResolveUtil.DOC_TYPE_PATTERN_SINGLE);
     }
 
     /**


### PR DESCRIPTION
Twig PsiComment has contained only comment text since PhpStorm 2020.1

issue in JetBrains tracker: https://youtrack.jetbrains.com/issue/WI-53129