### PR TITLE
Remove leading slash from storage location (#1543)

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/Settings.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/Settings.java
@@ -20,7 +20,7 @@ import java.util.List;
 @State(
        name = "Symfony2PluginSettings",
        storages = {
-               @Storage("/symfony2.xml")
+               @Storage("symfony2.xml")
        }
 )
 public class Settings implements PersistentStateComponent<Settings> {


### PR DESCRIPTION
Unwanted behavior: the plugin tries to save its settings in the root directory and fails because of lacking permissions.

Without the leading slash the settings go to the projects `.idea` folder as wanted.