### PR TITLE
support arrays for "resource" and "exclude" on autowrite which is use on Symfony >= 5 as default instead of global pattern

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlGoToDeclarationHandler.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlGoToDeclarationHandler.java
@@ -514,9 +514,9 @@ public class YamlGoToDeclarationHandler implements GotoDeclarationHandler {
         //   resource: '....'
         //   exclude: '....'
         if (valueText.endsWith("\\")) {
-            String resource = YamlHelper.getYamlKeyValueAsString(yamlKeyValue, "resource");
-            if (resource != null) {
-                String exclude = YamlHelper.getYamlKeyValueAsString(yamlKeyValue, "exclude");
+            Collection<String> resource = YamlHelper.getYamlKeyValueStringOrArray(yamlKeyValue, "resource");
+            if (!resource.isEmpty()) {
+                Collection<String> exclude = YamlHelper.getYamlKeyValueStringOrArray(yamlKeyValue, "exclude");
                 targets.addAll(getPhpClassFromResources(yamlKeyValue.getProject(), valueText, yamlKeyValue.getContainingFile().getVirtualFile(), resource, exclude));
             }
         }
@@ -527,7 +527,7 @@ public class YamlGoToDeclarationHandler implements GotoDeclarationHandler {
     }
 
     @NotNull
-    private static Collection<PhpClass> getPhpClassFromResources(@NotNull Project project, @NotNull String namespace, @NotNull VirtualFile source, @NotNull String resource, @Nullable String exclude) {
+    private static Collection<PhpClass> getPhpClassFromResources(@NotNull Project project, @NotNull String namespace, @NotNull VirtualFile source, @NotNull Collection<String> resource, @NotNull Collection<String> exclude) {
         Collection<PhpClass> phpClasses = new HashSet<>();
 
         for (PhpClass phpClass : PhpIndexUtil.getPhpClassInsideNamespace(project, "\\" + StringUtils.strip(namespace, "\\"))) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/AttributeValueAbstract.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/AttributeValueAbstract.java
@@ -59,4 +59,10 @@ abstract class AttributeValueAbstract implements AttributeValueInterface {
     public PsiElement getPsiElement() {
         return this.psiElement;
     }
+
+    @NotNull
+    @Override
+    public Collection<String> getStringArray(@NotNull String key) {
+        return Collections.emptyList();
+    }
 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/AttributeValueInterface.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/AttributeValueInterface.java
@@ -14,6 +14,9 @@ public interface AttributeValueInterface {
     @Nullable
     String getString(@NotNull String key);
 
+    @NotNull
+    Collection<String> getStringArray(@NotNull String key);
+
     @Nullable
     Boolean getBoolean(@NotNull String key);
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/DummyAttributeValue.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/DummyAttributeValue.java
@@ -25,6 +25,12 @@ public class DummyAttributeValue implements AttributeValueInterface {
         return null;
     }
 
+    @NotNull
+    @Override
+    public Collection<String> getStringArray(@NotNull String key) {
+        return Collections.emptySet();
+    }
+
     @Nullable
     @Override
     public Boolean getBoolean(@NotNull String key) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/XmlTagAttributeValue.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/XmlTagAttributeValue.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 /**
@@ -19,6 +20,16 @@ public class XmlTagAttributeValue extends AttributeValueAbstract {
     public XmlTagAttributeValue(@NotNull XmlTag xmlTag) {
         super(xmlTag);
         this.xmlTag = xmlTag;
+    }
+
+    @NotNull
+    @Override
+    public Collection<String> getStringArray(@NotNull String key) {
+        String string = getString(key);
+
+        return string != null
+            ? Collections.singleton(string)
+            : Collections.emptyList();
     }
 
     @Nullable

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/YamlKeyValueAttributeValue.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/attribute/value/YamlKeyValueAttributeValue.java
@@ -37,4 +37,10 @@ public class YamlKeyValueAttributeValue extends AttributeValueAbstract {
     public Collection<String> getTags() {
         return YamlHelper.collectServiceTags(yamlKeyValue);
     }
+
+    @NotNull
+    @Override
+    public Collection<String> getStringArray(@NotNull String key) {
+        return YamlHelper.getYamlKeyValueStringOrArray(yamlKeyValue, key);
+    }
 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/ImmutableDecoratorService.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/ImmutableDecoratorService.java
@@ -79,15 +79,15 @@ public class ImmutableDecoratorService implements ServiceInterface {
         return service.getDecorationInnerName();
     }
 
-    @Nullable
+    @NotNull
     @Override
-    public String getResource() {
+    public Collection<String> getResource() {
         return service.getResource();
     }
 
-    @Nullable
+    @NotNull
     @Override
-    public String getExclude() {
+    public Collection<String> getExclude() {
         return service.getExclude();
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/SerializableService.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/SerializableService.java
@@ -56,13 +56,13 @@ public class SerializableService implements ServiceSerializable {
     @Nullable
     private String parent;
 
-    @Nullable
+    @NotNull
     @SerializedName("resource")
-    private String resource;
+    private Collection<String> resource = new HashSet<>();
 
-    @Nullable
+    @NotNull
     @SerializedName("exclude")
-    private String exclude;
+    private Collection<String> exclude = new HashSet<>();
 
     @NotNull
     @SerializedName("tags")
@@ -183,15 +183,15 @@ public class SerializableService implements ServiceSerializable {
         return this;
     }
 
-    @Nullable
+    @NotNull
     @Override
-    public String getResource() {
+    public Collection<String> getResource() {
         return this.resource;
     }
 
-    @Nullable
+    @NotNull
     @Override
-    public String getExclude() {
+    public Collection<String> getExclude() {
         return this.exclude;
     }
 
@@ -206,12 +206,12 @@ public class SerializableService implements ServiceSerializable {
         return this;
     }
 
-    public SerializableService setResource(@Nullable String resource) {
+    public SerializableService setResource(@NotNull Collection<String> resource) {
         this.resource = resource;
         return this;
     }
 
-    public SerializableService setExclude(@Nullable String exclude) {
+    public SerializableService setExclude(@NotNull Collection<String> exclude) {
         this.exclude = exclude;
         return this;
     }
@@ -231,8 +231,8 @@ public class SerializableService implements ServiceSerializable {
             .append(this.decorates)
             .append(this.decorationInnerName)
             .append(this.parent)
-            .append(this.resource)
-            .append(this.exclude)
+            .append(new HashSet<>(this.resource))
+            .append(new HashSet<>(this.exclude))
             .append(new HashSet<>(this.tags))
             .toHashCode()
         ;
@@ -244,7 +244,6 @@ public class SerializableService implements ServiceSerializable {
             Objects.equals(((SerializableService) obj).id, this.id) &&
             Objects.equals(((SerializableService) obj).className, this.className) &&
             Objects.equals(((SerializableService) obj).isPublic, this.isPublic) &&
-            Objects.equals(((SerializableService) obj).isDeprecated, this.isDeprecated) &&
             Objects.equals(((SerializableService) obj).isLazy, this.isLazy) &&
             Objects.equals(((SerializableService) obj).isAbstract, this.isAbstract) &&
             Objects.equals(((SerializableService) obj).isAutowire, this.isAutowire) &&
@@ -253,8 +252,8 @@ public class SerializableService implements ServiceSerializable {
             Objects.equals(((SerializableService) obj).decorates, this.decorates) &&
             Objects.equals(((SerializableService) obj).decorationInnerName, this.decorationInnerName) &&
             Objects.equals(((SerializableService) obj).parent, this.parent) &&
-            Objects.equals(((SerializableService) obj).resource, this.resource) &&
-            Objects.equals(((SerializableService) obj).exclude, this.exclude) &&
+            Objects.equals(new HashSet<>(((SerializableService) obj).resource), new HashSet<>(this.resource)) &&
+            Objects.equals(new HashSet<>(((SerializableService) obj).exclude), new HashSet<>(this.exclude)) &&
             Objects.equals(new HashSet<>(((SerializableService) obj).tags), new HashSet<>(this.tags))
         ;
     }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/ServiceInterface.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/ServiceInterface.java
@@ -38,11 +38,11 @@ public interface ServiceInterface {
     @Nullable
     String getDecorationInnerName();
 
-    @Nullable
-    String getResource();
+    @NotNull
+    Collection<String> getResource();
 
-    @Nullable
-    String getExclude();
+    @NotNull
+    Collection<String> getExclude();
 
     @NotNull
     Collection<String> getTags();

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/XmlService.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/XmlService.java
@@ -7,6 +7,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 
 /**
@@ -94,16 +95,16 @@ public class XmlService implements ServiceInterface {
         return null;
     }
 
-    @Nullable
+    @NotNull
     @Override
-    public String getResource() {
-        return null;
+    public Collection<String> getResource() {
+        return Collections.emptyList();
     }
 
-    @Nullable
+    @NotNull
     @Override
-    public String getExclude() {
-        return null;
+    public Collection<String> getExclude() {
+        return Collections.emptyList();
     }
 
     @NotNull

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
@@ -183,8 +183,8 @@ public class ServiceContainerUtil {
             .setIsAutowire(attributes.getBoolean("autowire", serviceConsumer.getDefaults().isAutowire()))
             .setIsLazy(attributes.getBoolean("lazy"))
             .setIsPublic(attributes.getBoolean("public", serviceConsumer.getDefaults().isPublic()))
-            .setResource(attributes.getString("resource"))
-            .setExclude(attributes.getString("exclude"))
+            .setResource(attributes.getStringArray("resource"))
+            .setExclude(attributes.getStringArray("exclude"))
             .setTags(attributes.getTags());
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ServicesDefinitionStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ServicesDefinitionStubIndex.java
@@ -85,7 +85,7 @@ public class ServicesDefinitionStubIndex extends FileBasedIndexExtension<String,
 
     @Override
     public int getVersion() {
-        return 6;
+        return 7;
     }
 
     public static boolean isValidForIndex(FileContent inputData, PsiFile psiFile) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/yaml/YamlHelper.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/yaml/YamlHelper.java
@@ -351,6 +351,33 @@ public class YamlHelper {
         return getYamlKeyValueAsString(yamlKeyValue, keyName, false);
     }
 
+    /**
+     *  foo:
+     *     class: "name"
+     *
+     *  class:
+     *   - "name"
+     *   - "test"
+     */
+    @NotNull
+    public static Collection<String> getYamlKeyValueStringOrArray(@NotNull YAMLKeyValue yamlKeyValue, @NotNull String keyName) {
+        YAMLKeyValue childrenKeyValue = getYamlKeyValue(yamlKeyValue, keyName);
+        if (childrenKeyValue == null) {
+            return Collections.emptyList();
+        }
+
+        // class: [test]
+        // class:
+        //  - "test"
+        YAMLValue value = childrenKeyValue.getValue();
+        if(value instanceof YAMLSequence) {
+          return getYamlArrayValuesAsString((YAMLSequence) value);
+        }
+
+        // class: "test"
+        return Collections.singletonList(getYamlKeyValueAsString(yamlKeyValue, keyName));
+    }
+
     @Nullable
     public static String getYamlKeyValueAsString(@NotNull YAMLKeyValue yamlKeyValue, @NotNull String keyName, boolean ignoreCase) {
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/ServiceContainerUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/ServiceContainerUtilTest.java
@@ -109,7 +109,7 @@ public class ServiceContainerUtilTest extends SymfonyLightCodeInsightFixtureTest
         for (PsiFile psiFile : new PsiFile[]{xmlFile, ymlFile}) {
             ServiceInterface bar = ContainerUtil.find(ServiceContainerUtil.getServicesInFile(psiFile), MyStringServiceInterfaceCondition.create("non.defaults"));
             assertEquals(
-                "{\"id\":\"non.defaults\",\"class\":\"DateTime\",\"public\":false,\"lazy\":true,\"abstract\":true,\"autowire\":true,\"deprecated\":true,\"alias\":\"foo\",\"decorates\":\"foo\",\"decoration_inner_name\":\"foo\",\"parent\":\"foo\",\"tags\":[]}",
+                "{\"id\":\"non.defaults\",\"class\":\"DateTime\",\"public\":false,\"lazy\":true,\"abstract\":true,\"autowire\":true,\"deprecated\":true,\"alias\":\"foo\",\"decorates\":\"foo\",\"decoration_inner_name\":\"foo\",\"parent\":\"foo\",\"resource\":[],\"exclude\":[],\"tags\":[]}",
                 new Gson().toJson(bar)
             );
         }
@@ -137,7 +137,7 @@ public class ServiceContainerUtilTest extends SymfonyLightCodeInsightFixtureTest
         for (PsiFile psiFile : new PsiFile[]{xmlFile, ymlFile}) {
             ServiceInterface bar = ContainerUtil.find(ServiceContainerUtil.getServicesInFile(psiFile), MyStringServiceInterfaceCondition.create("defaults"));
             assertEquals(
-                "{\"id\":\"defaults\",\"class\":\"DateTime\",\"tags\":[]}",
+                "{\"id\":\"defaults\",\"class\":\"DateTime\",\"resource\":[],\"exclude\":[],\"tags\":[]}",
                 new Gson().toJson(bar)
             );
         }
@@ -210,6 +210,21 @@ public class ServiceContainerUtilTest extends SymfonyLightCodeInsightFixtureTest
         ServiceSerializable defaultsAlias = services.stream().filter(service -> "_yaml.defaults_alias".equals(service.getId())).findFirst().get();
         assertTrue(defaultsAlias.isAutowire());
         assertFalse(defaultsAlias.isPublic());
+    }
+
+    /**
+     * @see fr.adrienbrault.idea.symfony2plugin.dic.container.util.ServiceContainerUtil#getServicesInFile
+     */
+    public void testYamlFileScopeDefaultsForSymfony5() {
+        Collection<ServiceSerializable> services = ServiceContainerUtil.getServicesInFile(myFixture.configureByFile("services5.yml"));
+
+        ServiceSerializable appResourceSingle = services.stream().filter(service -> "AppSingle\\".equals(service.getId())).findFirst().get();
+        assertContainsElements(appResourceSingle.getResource(), "../src/*");
+        assertContainsElements(appResourceSingle.getExclude(), "../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}");
+
+        ServiceSerializable appResourceArray = services.stream().filter(service -> "AppArray\\".equals(service.getId())).findFirst().get();
+        assertContainsElements(appResourceArray.getResource(), "../src2/*", "../src/*");
+        assertContainsElements(appResourceArray.getExclude(), "../src/{DependencyInjection,Kernel.php}", "../src2/{Tests,Kernel.php}");
     }
 
     /**

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/fixtures/services5.yml
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/fixtures/services5.yml
@@ -1,0 +1,10 @@
+services:
+  AppSingle\:
+    resource: '../src/*'
+    exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+
+  AppArray\:
+    resource:
+      - '../src/*'
+      - '../src2/*'
+    exclude: ['../src/{DependencyInjection,Kernel.php}', '../src2/{Tests,Kernel.php}']

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/stubs/indexes/ServicesDefinitionStubIndexTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/stubs/indexes/ServicesDefinitionStubIndexTest.java
@@ -34,7 +34,7 @@ public class ServicesDefinitionStubIndexTest extends SymfonyLightCodeInsightFixt
         assertEquals("AppBundle\\Controller\\DefaultController", getFirstValue("foo.yml_id").getClassName());
 
         assertEquals("AppBundle\\Controller\\DefaultController", getFirstValue("foo.yml_id.private").getClassName());
-        assertEquals(false, getFirstValue("foo.yml_id.private").isPublic());
+        assertFalse(getFirstValue("foo.yml_id.private").isPublic());
     }
 
     public void testThatServiceIdOfXmlFileIsIndexed() {
@@ -85,16 +85,16 @@ public class ServicesDefinitionStubIndexTest extends SymfonyLightCodeInsightFixt
         ServiceInterface firstValue = getFirstValue("app\\controller\\");
 
         assertEquals("App\\Controller\\", firstValue.getId());
-        assertEquals("../src/Controller", firstValue.getResource());
-        assertEquals("../src/{Entity,Tests}", firstValue.getExclude());
+        assertContainsElements(firstValue.getResource(), "../src/Controller");
+        assertContainsElements(firstValue.getExclude(), "../src/{Entity,Tests}");
     }
 
     public void testThatResourceAndExcludeAttributesAreExtractedForXml() {
         ServiceInterface firstValue = getFirstValue("app\\xml\\");
 
         assertEquals("App\\Xml\\", firstValue.getId());
-        assertEquals("../src/*", firstValue.getResource());
-        assertEquals("../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}", firstValue.getExclude());
+        assertContainsElements(firstValue.getResource(), "../src/*");
+        assertContainsElements(firstValue.getExclude(), "../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}");
     }
 
     public void testThatTagAreInIndexForYaml() {

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/dict/ServiceUtilTempProjectTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/dict/ServiceUtilTempProjectTest.java
@@ -4,6 +4,9 @@ import com.intellij.openapi.vfs.VirtualFile;
 import fr.adrienbrault.idea.symfony2plugin.stubs.ServiceIndexUtil;
 import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyTempCodeInsightFixtureTestCase;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
@@ -24,19 +27,19 @@ public class ServiceUtilTempProjectTest extends SymfonyTempCodeInsightFixtureTes
                 "class Bar {}\n"
         );
 
-        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/*", null));
-        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/Foobar/Bar.php", null));
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/*"), Collections.emptyList()));
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/Foobar/Bar.php"), Collections.emptyList()));
 
-        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/{Foobar,Entity,Migrations,Tests,Kernel.php}", null));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/{Entity,Migrations,Tests,Kernel.php}", null));
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/{Foobar,Entity,Migrations,Tests,Kernel.php}"), Collections.emptyList()));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/{Entity,Migrations,Tests,Kernel.php}"), Collections.emptyList()));
 
         // exclude
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/*", "../src/*"));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/*", "../src/{Foobar,Kernel.php}"));
-        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/*", "../src/{Migrations,Kernel.php}"));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/*"), Collections.singleton("../src/*")));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/*"), Collections.singleton("../src/{Foobar,Kernel.php}")));
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/*"), Collections.singleton("../src/{Migrations,Kernel.php}")));
 
         // nested: not supported and must not break in exception
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php,Service/{IspConfiguration,DataCollection}}", null));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php,Service/{IspConfiguration,DataCollection}}"), Collections.emptyList()));
     }
 
     public void testServiceResourcesWithDepth() {
@@ -55,8 +58,8 @@ public class ServiceUtilTempProjectTest extends SymfonyTempCodeInsightFixtureTes
                 "class Bar {}\n"
         );
 
-        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../../*", null));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "../../*", "../../Bar"));
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../../*"), Collections.emptyList()));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../../*"), Collections.singleton("../../Bar")));
     }
 
     public void testPossibleResourceCondition() {
@@ -74,14 +77,34 @@ public class ServiceUtilTempProjectTest extends SymfonyTempCodeInsightFixtureTes
                 "class Bar {}\n"
         );
 
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "", ""));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "src", "src"));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "/aaa", "/aaaa"));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "/", "/"));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "a", "/"));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "", null));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "src", null));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "/", null));
-        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, "..", ".."));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton(""), Collections.singleton("")));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("src"), Collections.singleton("src")));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("/aaa"), Collections.singleton("/aaaa")));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("/"), Collections.singleton("/")));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("a"), Collections.singleton("/")));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton(""), Collections.emptyList()));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("src"), Collections.emptyList()));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("/"), Collections.emptyList()));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton(".."), Collections.singleton("..")));
     }
+
+    public void testServiceResourcesWithArrays() {
+        VirtualFile file = createFile("config/services.yml");
+
+        VirtualFile file2 = createFile(
+            "src/Foobar/Bar.php",
+            "<?php\n"
+        );
+
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/*"), Collections.emptyList()));
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Arrays.asList("../src2/Foobar/Bar.php", "../src/Foobar/Bar.php"), Collections.emptyList()));
+
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Arrays.asList("../src/{Entity,Tests,Kernel.php}", "../src/{Foobar,EntityKernel.php}"), Collections.emptyList()));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/{Entity,Migrations,Tests,Kernel.php}"), Collections.emptyList()));
+
+        // exclude
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Arrays.asList("../foobar/*", "../src/*"), Arrays.asList("../foo/*", "../src/*")));
+        assertFalse(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/*"), Arrays.asList("../src/{Bar,Kernel.php}", "../src/{Foobar,Kernel.php}")));
+        assertTrue(ServiceIndexUtil.matchesResourcesGlob(file, file2, Collections.singleton("../src/*"), Arrays.asList("../src/{Migrations,Kernel.php}", "../src/{Migrations2,Kernel.php}")));
+   }
 }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/yaml/YamlHelperLightTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/yaml/YamlHelperLightTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
@@ -149,6 +150,39 @@ public class YamlHelperLightTest extends SymfonyLightCodeInsightFixtureTestCase 
                 "method"
             ));
         }
+    }
+
+    /**
+     * @see fr.adrienbrault.idea.symfony2plugin.util.yaml.YamlHelper#getYamlKeyValueStringOrArray
+     */
+    public void testGetYamlKeyValueStringOrArray() {
+        YAMLKeyValue fromText = YamlPsiElementFactory.createFromText(getProject(), YAMLKeyValue.class, "" +
+            "foo:\n" +
+            "   tags: 'foo'\n"
+        );
+
+        Collection<String> tags = YamlHelper.getYamlKeyValueStringOrArray(fromText,"tags");
+        assertTrue(tags.stream().anyMatch("foo"::equalsIgnoreCase));
+
+        YAMLKeyValue fromText2 = YamlPsiElementFactory.createFromText(getProject(), YAMLKeyValue.class, "" +
+            "foo:\n" +
+            "   tags: ['bar1', 'bar2']\n"
+        );
+
+        Collection<String> tags2 = YamlHelper.getYamlKeyValueStringOrArray(fromText2,"tags");
+        assertTrue(tags2.stream().anyMatch("bar1"::equalsIgnoreCase));
+        assertTrue(tags2.stream().anyMatch("bar2"::equalsIgnoreCase));
+
+        YAMLKeyValue fromText3 = YamlPsiElementFactory.createFromText(getProject(), YAMLKeyValue.class, "" +
+            "foo:\n" +
+            "   tags:\n" +
+            "       - foo1\n" +
+            "       - foo2\n"
+        );
+
+        Collection<String> tags3 = YamlHelper.getYamlKeyValueStringOrArray(fromText3,"tags");
+        assertTrue(tags3.stream().anyMatch("foo1"::equalsIgnoreCase));
+        assertTrue(tags3.stream().anyMatch("foo2"::equalsIgnoreCase));
     }
 
     /**


### PR DESCRIPTION
- [x] Index process needs array support