### PR TITLE
Removed hardcoded background in Symfony Create Service Form output textarea 

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/action/ui/SymfonyCreateService.form
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/action/ui/SymfonyCreateService.form
@@ -175,7 +175,6 @@
                       <component id="69cac" class="javax.swing.JTextArea" binding="textAreaOutput">
                         <constraints/>
                         <properties>
-                          <background color="-1"/>
                           <editable value="false"/>
                           <font name="Courier New"/>
                           <lineWrap value="true"/>


### PR DESCRIPTION
PR removes hardcoded white background in Symfony Create Service Form output textarea field. Currently Symfony Create Service Form  with "Dracula" theme look like this:

![Zrzut ekranu z 2021-03-27 20-54-22](https://user-images.githubusercontent.com/211967/112733323-a93d2380-8f3f-11eb-8631-72c689097294.png)

After applying the patch:

![Zrzut ekranu z 2021-03-27 20-56-06](https://user-images.githubusercontent.com/211967/112733389-18b31300-8f40-11eb-9bb0-98a78558d1c4.png)

and with "Intelij light" theme:

![Zrzut ekranu z 2021-03-27 20-55-42](https://user-images.githubusercontent.com/211967/112733504-b3135680-8f40-11eb-8332-f5f3e47dc892.png)

