### PR TITLE
Removed redundant null check in phpStringLiteralExpressionClassReference method

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/php/PhpConfigReferenceContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/php/PhpConfigReferenceContributor.java
@@ -162,7 +162,7 @@ public class PhpConfigReferenceContributor extends PsiReferenceContributor {
         }
 
         ParameterList parameterList = (ParameterList) psiElement.getContext();
-        if (parameterList == null || !(parameterList.getContext() instanceof NewExpression)) {
+        if (!(parameterList.getContext() instanceof NewExpression)) {
             return false;
         }
 


### PR DESCRIPTION
Static code analytics reports that `parameterList == null` condition is always `false` in the following statement

https://github.com/Haehnchen/idea-php-symfony2-plugin/blob/7fc5555f22dc3df7f1e34e8c4c7e59d54339c39e/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/php/PhpConfigReferenceContributor.java#L164-L167

as the result of `psiElement.getContext()` is already tested against `null` in: 

https://github.com/Haehnchen/idea-php-symfony2-plugin/blob/80d33630d2dc9eaa959e64b8d914165046abf1b9/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/php/PhpConfigReferenceContributor.java#L160-L162
