### PR TITLE
Fixed #1599: Added protection against infinite recursion in PhpElementsUtil.getImplementedMethods

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/PhpElementsUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/PhpElementsUtil.java
@@ -575,14 +575,16 @@ public class PhpElementsUtil {
     }
 
     public static Method[] getImplementedMethods(@NotNull Method method) {
-        ArrayList<Method> items = getImplementedMethods(method.getContainingClass(), method, new ArrayList<>());
+        ArrayList<Method> items = getImplementedMethods(method.getContainingClass(), method, new ArrayList<>(), new HashSet<>());
         return items.toArray(new Method[items.size()]);
     }
 
-    private static ArrayList<Method> getImplementedMethods(@Nullable PhpClass phpClass, @NotNull Method method, ArrayList<Method> implementedMethods) {
-        if (phpClass == null) {
+    private static ArrayList<Method> getImplementedMethods(@Nullable PhpClass phpClass, @NotNull Method method, ArrayList<Method> implementedMethods, Set<PhpClass> visitedClasses) {
+        if (phpClass == null || visitedClasses.contains(phpClass)) {
             return implementedMethods;
         }
+
+        visitedClasses.add(phpClass);
 
         Method[] methods = phpClass.getOwnMethods();
         for (Method ownMethod : methods) {
@@ -592,10 +594,10 @@ public class PhpElementsUtil {
         }
 
         for(PhpClass interfaceClass: phpClass.getImplementedInterfaces()) {
-            getImplementedMethods(interfaceClass, method, implementedMethods);
+            getImplementedMethods(interfaceClass, method, implementedMethods, visitedClasses);
         }
 
-        getImplementedMethods(phpClass.getSuperClass(), method, implementedMethods);
+        getImplementedMethods(phpClass.getSuperClass(), method, implementedMethods, visitedClasses);
 
         return implementedMethods;
     }


### PR DESCRIPTION
Error reported as #1599 could be reproduced by creating the following class hierarchy:

```php
class A extends B { public function foo() { /* .... */ }
class B extends A {  /* .... */ }
```

and then calling `PhpElementsUtil.getImplementedMethods(...)` for `foo` method.

## Note to reviewers 

Similar issue occurs in `de.espend.idea.php.toolbox.matcher.php.docTag.Php DocUtil.getImplementedMethods` but seperate PR is requried as this class is not part of this repository.

TODO:
- [X] Reproduce issue
- [X] Push unit test
- [X] Wait for CI to confirm issue (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/222740515#L305-L306)
- [x] Push patch 
- [x] Wait for CI to confirm patch (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/222740696)