### PR TITLE
Fixed #1575: Inspection "Container sensitivity" is not expected to be emitted for default env values

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/inspection/CaseSensitivityServiceInspection.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/inspection/CaseSensitivityServiceInspection.java
@@ -78,7 +78,7 @@ public class CaseSensitivityServiceInspection extends LocalInspectionTool {
         // services and parameter
         YamlHelper.processKeysAfterRoot(psiFile, yamlKeyValue -> {
             String keyText = yamlKeyValue.getKeyText();
-            if(StringUtils.isNotBlank(keyText) && !keyText.equals(keyText.toLowerCase()) && !YamlHelper.isClassServiceId(keyText)) {
+            if(StringUtils.isNotBlank(keyText) && !keyText.equals(keyText.toLowerCase()) && !YamlHelper.isClassServiceId(keyText) && !YamlHelper.isDefaultEnvValue(keyText)) {
                 PsiElement firstChild = yamlKeyValue.getFirstChild();
                 if(firstChild != null) {
                     holder.registerProblem(firstChild, SYMFONY_LOWERCASE_LETTERS_FOR_SERVICE, ProblemHighlightType.WEAK_WARNING);

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/yaml/YamlHelper.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/yaml/YamlHelper.java
@@ -1033,6 +1033,13 @@ public class YamlHelper {
     }
 
     /**
+     * Returns true if given parameter name is default value for ENV variable.
+     */
+    public static boolean isDefaultEnvValue(@NotNull String parameterName) {
+        return parameterName.length() > 5 && parameterName.startsWith("env(") && parameterName.endsWith(")");
+    }
+
+    /**
      * service_name:
      *   class: FOOBAR
      *   calls:

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/inspection/CaseSensitivityServiceInspectionTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/inspection/CaseSensitivityServiceInspectionTest.java
@@ -79,6 +79,11 @@ public class CaseSensitivityServiceInspectionTest extends SymfonyLightCodeInsigh
                 "        class: DateTime",
             "Symfony: lowercase letters for service and parameter"
         );
+
+        assertLocalInspectionNotContains("service.yml", "parameters:\n" +
+                "    env(SECRET<caret>): 'some_secret'\n",
+        "Symfony: lowercase letters for service and parameter"
+        );
     }
 
     public void testCaseSensitivityForYamlExpressionsNotInspected() {


### PR DESCRIPTION
Added additional check to fr.adrienbrault.idea.symfony2plugin.dic.inspection.CaseSensitivityServiceInspection if given YAML key text is not default env value. I wans't able to reproduce issue in other file formats. 

Open questions:

* Should `!YamlHelper.isDefaultEnvValue(keyText)` condition be evaluated only if `parameters` node is ancestor of keyText? 

### TODO:

- [X] Reproduce issue
- [X] Push unit test
- [X] Wait for CI to confirm issue (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/222747282)
- [x] Push patch 
- [x] Wait for CI to confirm patch (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/222747447)