### PR TITLE
Fixed #1640: Go to declaration throws ArrayIndexOutOfBoundsException on empty class const name

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
@@ -731,6 +731,11 @@ public class ServiceContainerUtil {
         contents = contents.replaceAll(":+", ":");
         String[] split = contents.split(":");
 
+        if (split.length < 2) {
+            // Empty const name e.g. "\\App\\Foo::"
+            return Collections.emptyList();
+        }
+
         Collection<PsiElement> psiElements = new ArrayList<>();
         for (PhpClass phpClass : PhpElementsUtil.getClassesInterface(project, split[0])) {
             Field fieldByName = phpClass.findFieldByName(split[1], true);

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/ServiceContainerUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/ServiceContainerUtilTest.java
@@ -357,6 +357,10 @@ public class ServiceContainerUtilTest extends SymfonyLightCodeInsightFixtureTest
         assertFalse(arguments.contains("private"));
     }
 
+    public void testGetTargetsForConstantForEmptyClassConstName() {
+        assertEmpty(ServiceContainerUtil.getTargetsForConstant(getProject(), "\\App\\Service\\FooService::"));
+    }
+
     private static class MyStringServiceInterfaceCondition implements Condition<ServiceInterface> {
 
         @NotNull

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/fixtures/classes.php
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/container/util/fixtures/classes.php
@@ -27,3 +27,11 @@ namespace App\Controller
         }
     }
 }
+
+namespace App\Service
+{
+    class FooService
+    {
+        public const FOO = "foo";
+    }
+}


### PR DESCRIPTION
Fixed https://github.com/Haehnchen/idea-php-symfony2-plugin/issues/1640 by adding additional check if results of https://github.com/Haehnchen/idea-php-symfony2-plugin/blob/c8388e2429e6373db782c27bea15075cbec4a00b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java#L732 contains at least 2 elements before accessing them
### TODO:

- [X] Reproduce issue
- [X] Push unit test
- [X] Wait for CI to confirm issue (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/225304753#L305-L308)
- [x] Push patch 
- [X] Wait for CI to confirm patch (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/225305325)