### PR TITLE
Fixed #1631: PhpConstGotoCompletionProvider throws IndexOutOfBoundsException when cursor is before scope operator

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/completion/PhpConstGotoCompletionProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/completion/PhpConstGotoCompletionProvider.java
@@ -42,12 +42,16 @@ public class PhpConstGotoCompletionProvider extends GotoCompletionProvider {
         PhpIndex phpIndex = PhpIndex.getInstance(this.getProject());
         CompletionResultSet resultSet = arguments.getResultSet();
 
-        final String prefix = getElement().getText().replace(CompletionUtil.DUMMY_IDENTIFIER_TRIMMED, "");
+        var elementText = getElement().getText();
+        var scopeOperatorPos = elementText.indexOf(SCOPE_OPERATOR);
+        var cursorPos = elementText.indexOf(CompletionUtil.DUMMY_IDENTIFIER_TRIMMED);
 
         // Class constants:  !php/const Foo::<caret>
-        if (prefix.contains(SCOPE_OPERATOR)) {
-            String classFQN = prefix.substring(0, getElement().getText().indexOf(SCOPE_OPERATOR));
-            PhpClass phpClass = PhpElementsUtil.getClassInterface(this.getProject(), classFQN);
+        if (scopeOperatorPos > -1 && scopeOperatorPos < cursorPos) {
+            var prefix = elementText.replace(CompletionUtil.DUMMY_IDENTIFIER_TRIMMED, "");
+            var classFQN = prefix.substring(0, scopeOperatorPos);
+            var phpClass = PhpElementsUtil.getClassInterface(this.getProject(), classFQN);
+
             if (phpClass != null) {
                 // reset the prefix matcher, starting after ::
                 resultSet = resultSet.withPrefixMatcher(prefix.substring(prefix.indexOf(SCOPE_OPERATOR) + 2));

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/YamlGotoCompletionRegistrarTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/YamlGotoCompletionRegistrarTest.java
@@ -103,12 +103,33 @@ public class YamlGotoCompletionRegistrarTest extends SymfonyLightCodeInsightFixt
     }
 
     public void testThatPhpConstAreCompletedAndNavigable() {
-        assertCompletionIsEmpty(YAMLFileType.YML, "" +
-                "services:\n" +
-                "    foo:\n" +
-                "       class: Foo\\Foobar\n" +
-                "       arguments: \n" +
-                "           - !php/const Foo\\Bar<caret>::BAZ\n"
+        assertCompletionContains(
+            YAMLFileType.YML,
+            "services:\n" +
+            "    foo:\n" +
+            "       class: Foo\\Foobar\n" +
+            "       arguments: \n" +
+            "           - !php/const <caret>\n",
+            "Bar", "Foobar"
+        );
+
+        assertCompletionContains(
+            YAMLFileType.YML,
+            "services:\n" +
+            "    foo:\n" +
+            "       class: Foo\\Foobar\n" +
+            "       arguments: \n" +
+            "           - !php/const Foo\\Bar::<caret>\n",
+            "BAZ"
+        );
+
+        assertCompletionIsEmpty(
+            YAMLFileType.YML,
+            "services:\n" +
+            "    foo:\n" +
+            "       class: Foo\\Foobar\n" +
+            "       arguments: \n" +
+            "           - !php/const Foo\\Bar<caret>::BAZ\n"
         );
     }
 }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/YamlGotoCompletionRegistrarTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/YamlGotoCompletionRegistrarTest.java
@@ -101,4 +101,14 @@ public class YamlGotoCompletionRegistrarTest extends SymfonyLightCodeInsightFixt
             lookupElement -> "foo".equals(lookupElement.getItemText()) && lookupElement.isItemTextBold() && lookupElement.isItemTextBold()
         );
     }
+
+    public void testThatPhpConstAreCompletedAndNavigable() {
+        assertCompletionIsEmpty(YAMLFileType.YML, "" +
+                "services:\n" +
+                "    foo:\n" +
+                "       class: Foo\\Foobar\n" +
+                "       arguments: \n" +
+                "           - !php/const Foo\\Bar<caret>::BAZ\n"
+        );
+    }
 }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/fixtures/YamlGotoCompletionRegistrar.php
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/fixtures/YamlGotoCompletionRegistrar.php
@@ -4,10 +4,13 @@ namespace Foo
 {
     class Bar
     {
+        public const BAZ = 'baz';
+
         public function create() {}
     }
 
     class Foobar extends Bar
     {
+        public function __construct($arg = null) {}
     }
 }


### PR DESCRIPTION
Skipp autocompletion for class consts. if cursor is placed before scope operator. This behaviour is consistent with class const. autocompletion in PHP code.

### TODO:

- [X] Reproduce issue
- [X] Push unit test
- [X] Wait for CI to confirm issue (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/226020145#L305-L345)
- [x] Push patch 
- [x] Wait for CI to confirm patch (https://travis-ci.com/github/Haehnchen/idea-php-symfony2-plugin/builds/226020573)
- [x] Add missing test coverage for other use cases