### PR TITLE
Fixed #1667: Rename refactoring ignores constants inside yaml files 

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/ConstantYamlReference.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/ConstantYamlReference.java
@@ -1,0 +1,50 @@
+package fr.adrienbrault.idea.symfony2plugin.config.yaml;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.PsiPolyVariantReferenceBase;
+import com.intellij.psi.ResolveResult;
+import com.intellij.util.IncorrectOperationException;
+import fr.adrienbrault.idea.symfony2plugin.dic.container.util.ServiceContainerUtil;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.yaml.psi.YAMLScalar;
+
+public class ConstantYamlReference extends PsiPolyVariantReferenceBase<YAMLScalar> {
+
+    public ConstantYamlReference(@NotNull YAMLScalar element) {
+        super(element);
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] multiResolve(boolean incompleteCode) {
+        var constantName = getElement().getTextValue();
+        if (StringUtils.isBlank(constantName)) {
+            return ResolveResult.EMPTY_ARRAY;
+        }
+
+        return PsiElementResolveResult.createResults(
+            ServiceContainerUtil.getTargetsForConstant(getElement().getProject(), constantName)
+        );
+    }
+
+    @Override
+    public PsiElement handleElementRename(@NotNull String newElementName) throws IncorrectOperationException {
+        var constantName = getValue();
+        if (isClassConst(constantName)) {
+            newElementName = getClassName(constantName) + "::" + newElementName;
+        }
+
+        return super.handleElementRename(newElementName);
+    }
+
+    private boolean isClassConst(@NotNull String value) {
+        return value.contains("::");
+    }
+
+    @NotNull
+    private String getClassName(@NotNull String value) {
+        return value.substring(0, value.indexOf("::"));
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlReferenceContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlReferenceContributor.java
@@ -1,0 +1,41 @@
+package fr.adrienbrault.idea.symfony2plugin.config.yaml;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.StandardPatterns;
+import com.intellij.psi.*;
+import com.intellij.util.ProcessingContext;
+import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.yaml.psi.YAMLScalar;
+
+public class YamlReferenceContributor extends PsiReferenceContributor {
+    private static final String TAG_PHP_CONST = "!php/const";
+
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+        registrar.registerReferenceProvider(
+            PlatformPatterns.psiElement(YAMLScalar.class)
+                .withText(StandardPatterns.string()
+                    .contains(TAG_PHP_CONST)
+                ),
+            new PsiReferenceProvider() {
+                @NotNull
+                @Override
+                public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                    if (!Symfony2ProjectComponent.isEnabled(element)) {
+                        return PsiReference.EMPTY_ARRAY;
+                    }
+
+                    var scalar = (YAMLScalar)element;
+                    if (scalar.getTextValue().isEmpty()) {
+                        return PsiReference.EMPTY_ARRAY;
+                    }
+
+                    return new PsiReference[]{
+                        new ConstantYamlReference(scalar)
+                    };
+                }
+            }
+        );
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -170,6 +170,7 @@
         <psi.referenceContributor implementation="fr.adrienbrault.idea.symfony2plugin.routing.PhpRouteReferenceContributor"/>
         <psi.referenceContributor implementation="fr.adrienbrault.idea.symfony2plugin.config.xml.XmlReferenceContributor"/>
         <psi.referenceContributor implementation="fr.adrienbrault.idea.symfony2plugin.config.php.PhpConfigReferenceContributor"/>
+        <psi.referenceContributor implementation="fr.adrienbrault.idea.symfony2plugin.config.yaml.YamlReferenceContributor"/>
         <psi.referenceContributor implementation="fr.adrienbrault.idea.symfony2plugin.form.FormTypeReferenceContributor"/>
         <psi.referenceContributor implementation="fr.adrienbrault.idea.symfony2plugin.util.DocHashTagReferenceContributor"/>
         <psi.referenceContributor implementation="fr.adrienbrault.idea.symfony2plugin.util.MethodParameterReferenceContributor"/>

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/yaml/YamlReferenceContributorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/yaml/YamlReferenceContributorTest.java
@@ -1,0 +1,39 @@
+package fr.adrienbrault.idea.symfony2plugin.tests.config.yaml;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.jetbrains.php.lang.psi.elements.Field;
+import com.jetbrains.php.lang.psi.elements.PhpDefine;
+import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+import org.jetbrains.yaml.YAMLFileType;
+
+public class YamlReferenceContributorTest extends SymfonyLightCodeInsightFixtureTestCase {
+
+    public void setUp() throws Exception {
+        super.setUp();
+        myFixture.copyFileToProject("YamlReferenceContributor.php");
+    }
+
+    public String getTestDataPath() {
+        return "src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/yaml/fixtures";
+    }
+
+    public void testConstantProvidesReferences() {
+        assertReferenceMatchOnParent(
+            YAMLFileType.YML,
+            "services:\n" +
+                "  app.service.example:\n" +
+                "    arguments:\n" +
+                "      - !php/const CONST_<caret>FOO\n",
+            PlatformPatterns.psiElement(PhpDefine.class).withName("CONST_FOO")
+        );
+
+        assertReferenceMatchOnParent(
+            YAMLFileType.YML,
+            "services:\n" +
+            "  app.service.example:\n" +
+            "    arguments:\n" +
+            "      - !php/const Foo\\Bar::F<caret>OO\n",
+            PlatformPatterns.psiElement(Field.class).withName("FOO")
+        );
+    }
+}

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/yaml/fixtures/YamlReferenceContributor.php
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/yaml/fixtures/YamlReferenceContributor.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace
+{
+    define('CONST_FOO', 'CONST_FOO');
+}
+
+namespace Foo
+{
+    class Bar
+    {
+        const FOO = 'foo';
+    }
+}


### PR DESCRIPTION
Fixed #1667 by implementing PsiReferenceContributor. Patch demo: https://youtu.be/NkjXxbpb1Yc

### TODO:

- [X] Reproduce issue
- [X] Push unit test
- [X] Wait for CI to confirm issue (https://github.com/Haehnchen/idea-php-symfony2-plugin/pull/1683/checks?check_run_id=3213209482#step:8:52)
- [x] Push patch 
- [x] Wait for CI to confirm patch (https://github.com/Haehnchen/idea-php-symfony2-plugin/pull/1683/checks?check_run_id=3213243912)