### PR TITLE
Fixed #1674: duplicated route prefix in profiler urls

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/profiler/utils/ProfilerUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/profiler/utils/ProfilerUtil.java
@@ -128,7 +128,7 @@ public class ProfilerUtil {
             if(tokenLink != null) {
                 String href = tokenLink.getAttributeValue("href");
                 if(StringUtils.isNotBlank(href)) {
-                    profilerUrl = StringUtils.stripEnd(baseUrl, "/") + href;
+                    profilerUrl = getProfilerAbsoluteUrl(baseUrl, href);
                 }
             }
 
@@ -151,6 +151,11 @@ public class ProfilerUtil {
         }
 
         return requests;
+    }
+
+    @NotNull
+    private static String getProfilerAbsoluteUrl(@NotNull String baseUrl, @NotNull String href) {
+        return StringUtils.stripEnd(baseUrl, "/") + href.substring(href.indexOf("/_profiler/"));
     }
 
     @NotNull

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/profiler/ProfilerUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/profiler/ProfilerUtilTest.java
@@ -40,6 +40,22 @@ public class ProfilerUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
     }
 
     /**
+     * @see ProfilerUtil#createRequestsFromIndexHtml
+     */
+    public void testCreateRequestsFromIndexHtmlRemovesProfilerRoutePrefixFromTokenLinks() {
+        PsiFile psiFile = myFixture.configureByFile("profiler-index-with-route-prefix.html");
+        Collection<ProfilerRequestInterface> requests = ProfilerUtil.createRequestsFromIndexHtml(getProject(), psiFile.getText(), "http://127.0.0.1:8000/prefix/");
+
+        ProfilerRequestInterface request = requests.iterator().next();
+
+        assertEquals("a9eaab", request.getHash());
+        assertEquals("GET", request.getMethod());
+        assertEquals("http://127.0.0.1:8000/prefix/_profiler/search/results?ip=&amp;limit=10", request.getUrl());
+        assertEquals("http://127.0.0.1:8000/prefix/_profiler/a9eaab", request.getProfilerUrl());
+        assertEquals(404, request.getStatusCode());
+    }
+
+    /**
      * @see ProfilerUtil#getRequestAttributes
      */
     public void testGetRequestValues() {

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/profiler/fixtures/profiler-index-with-route-prefix.html
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/profiler/fixtures/profiler-index-with-route-prefix.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="robots" content="noindex,nofollow" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Symfony Profiler</title>
+
+</head>
+<body>
+<div id="header">
+    <div class="container">
+        <h1>            Symfony <span>Profiler</span></h1>
+
+        <div class="search">
+            <form method="get" action="https://symfony.com/search" target="_blank">
+                <div class="form-row">
+                    <input name="q" id="search-id" type="search" placeholder="search on symfony.com">
+                    <button type="submit" class="btn">Search</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+
+<div id="summary">
+    <div class="status">
+        <div class="container">
+            <h2>Profile Search</h2>
+        </div>
+    </div>
+</div>
+
+<div id="content" class="container">
+    <div id="main">
+        <div id="collector-wrapper">
+            <div id="collector-content">
+
+                <h2>10 results found</h2>
+
+                <table id="search-results">
+                    <thead>
+                    <tr>
+                        <th scope="col" class="text-center">Status</th>
+                        <th scope="col">IP</th>
+                        <th scope="col">Method</th>
+                        <th scope="col">URL</th>
+                        <th scope="col">Time</th>
+                        <th scope="col">Token</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-error">404</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/a9eaab/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/a9eaab/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/prefix/_profiler/search/results?ip=&amp;limit=10
+                            <a href="/prefix/_profiler/a9eaab/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/prefix/_profiler/search/results%3Fip%3D%26limit%3D10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">28-Sep-2016</span>
+                            <span class="nowrap newline">19:35:14</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/a9eaab">a9eaab</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-success">200</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/b5e1bd/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/b5e1bd/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/prefix/_profiler/search/results?ip=&amp;limit=10
+                            <a href="/prefix/_profiler/b5e1bd/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/prefix/_profiler/search/results%3Fip%3D%26limit%3D10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">28-Sep-2016</span>
+                            <span class="nowrap newline">19:35:14</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/b5e1bd">b5e1bd</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-warning">301</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/3afd6f/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/3afd6f/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/prefix/_profiler
+                            <a href="/prefix/_profiler/3afd6f/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/prefix/_profiler" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">28-Sep-2016</span>
+                            <span class="nowrap newline">19:23:35</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/3afd6f">3afd6f</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-error">404</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/0fd1e4/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/0fd1e4/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/
+                            <a href="/prefix/_profiler/0fd1e4/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">28-Sep-2016</span>
+                            <span class="nowrap newline">19:23:21</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/0fd1e4">0fd1e4</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-success">200</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/ab269a/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/ab269a/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/
+                            <a href="/prefix/_profiler/ab269a/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">28-Sep-2016</span>
+                            <span class="nowrap newline">19:23:21</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/ab269a">ab269a</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-error">500</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/eb5573/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/eb5573/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/foobar
+                            <a href="/prefix/_profiler/eb5573/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/foobar" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">18-Sep-2016</span>
+                            <span class="nowrap newline">10:12:38</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/eb5573">eb5573</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-success">200</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/d3f91a/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/d3f91a/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/foobar
+                            <a href="/prefix/_profiler/d3f91a/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/foobar" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">18-Sep-2016</span>
+                            <span class="nowrap newline">10:12:38</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/d3f91a">d3f91a</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-error">500</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/d0d721/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/d0d721/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/foobar
+                            <a href="/prefix/_profiler/d0d721/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/foobar" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">18-Sep-2016</span>
+                            <span class="nowrap newline">09:56:40</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/d0d721">d0d721</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-success">200</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/b64e3a/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/b64e3a/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/foobar
+                            <a href="/prefix/_profiler/b64e3a/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/foobar" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">18-Sep-2016</span>
+                            <span class="nowrap newline">09:56:40</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/b64e3a">b64e3a</a></td>
+                    </tr>
+
+                    <tr>
+                        <td class="text-center">
+                            <span class="label status-error">500</span>
+                        </td>
+                        <td>
+                            <span class="nowrap">127.0.0.1</span>
+                            <a href="/prefix/_profiler/2ded8a/search/results?ip=127.0.0.1&amp;limit=10" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td>
+                            GET
+                            <a href="/prefix/_profiler/2ded8a/search/results?ip=&amp;limit=10&amp;method=GET" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="break-long-words">
+                            http://127.0.0.1:8000/foobar
+                            <a href="/prefix/_profiler/2ded8a/search/results?ip=&amp;limit=10&amp;url=http%3A//127.0.0.1%3A8000/foobar" title="Search">
+                                    <span title="Search" class="sf-icon sf-search"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="24" height="24" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+    <path fill="#AAAAAA"/>
+</svg>
+</span>
+                            </a>
+                        </td>
+                        <td class="text-small">
+                            <span class="nowrap">18-Sep-2016</span>
+                            <span class="nowrap newline">09:55:55</span>
+                        </td>
+                        <td class="nowrap"><a href="/prefix/_profiler/2ded8a">2ded8a</a></td>
+                    </tr>
+                    </tbody>
+                </table>
+
+            </div>
+        </div>
+
+        <div id="sidebar">
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Steps to reproduce

1. Define prefix for profiler routes in Symfony application e.g,

```yaml
# web_profiler.yaml 
# ...

web_profiler_profiler:
    resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
    prefix: /prefix/_profiler
``` 

2. Configure plugin as described in #1674 
3. Open profiler menu 

### Proposed patch

Proposed patch ignores everything before `/_profiler/` segment (as is already part of the base url) when extracting profile URL from href attribute.

### TODO:

- [X] Reproduce issue
- [X] Push unit test
- [X] Wait for CI to confirm issue (https://github.com/Haehnchen/idea-php-symfony2-plugin/pull/1685/checks?check_run_id=3214707926#step:8:51) 
- [X] Push patch 
- [x] Wait for CI to confirm patch (https://github.com/Haehnchen/idea-php-symfony2-plugin/runs/3214750041#step:8:58)