### PR TITLE
Added missing services keywords to YamlCompletionContributor

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlCompletionContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlCompletionContributor.java
@@ -85,9 +85,15 @@ public class YamlCompletionContributor extends CompletionContributor {
         put("decorates", null);
         put("decoration_inner_name", null);
         put("decoration_priority", "(int) >= 2.8");
+        put("decoration_on_invalid", "(exception|ignore|null) >= 4.4");
         put("shared", "(bool) >= 3.0");
         put("resource", "(string) >= 3.3");
         put("autoconfigure", "(bool) >= 3.3");
+        put("properties", ">= 5.1");
+        put("configurator", ">= 2.8");
+        put("bind", ">= 2.8");
+        put("file", ">= 2.8");
+        put("exclude", ">= 2.8");
     }});
 
     private static final Map<String, String> ROUTE_KEYS = Collections.unmodifiableMap(new HashMap<String, String>() {{

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/YamlCompletionContributorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/yaml/YamlCompletionContributorTest.java
@@ -318,6 +318,48 @@ public class YamlCompletionContributorTest extends SymfonyLightCodeInsightFixtur
         );
     }
 
+    public void testKeywordsCompletionInsideServiceDefinition() {
+        var exceptedKeywords = new String[] {
+            "abstract",
+            "alias",
+            "arguments",
+            "autoconfigure",
+            "autowire",
+            "autowiring_types",
+            "bind",
+            "class",
+            "configurator",
+            "decorates",
+            "decoration_inner_name",
+            "decoration_on_invalid",
+            "decoration_priority",
+            "deprecated",
+            "exclude",
+            "factory",
+            "factory_class",
+            "factory_method",
+            "factory_service",
+            "file",
+            "lazy",
+            "parent",
+            "properties",
+            "public",
+            "resource",
+            "scope",
+            "shared",
+            "synchronized",
+            "synthetic",
+            "tags"
+        };
+
+        assertCompletionContains(YAMLFileType.YML, "" +
+            "services:\n" +
+            "    app.foo.service:\n" +
+            "        <caret>\n",
+            exceptedKeywords
+        );
+    }
+
     private void assertCompletion3rdInvocationContains(String configureByText, String... lookupStrings) {
         myFixture.configureByText(YAMLFileType.YML, configureByText);
         myFixture.complete(CompletionType.BASIC, 3);


### PR DESCRIPTION
Added missing

* `decoration_on_invalid` 
* `properties` 
* `configurator` 
* `bind` 
* `file` 
* `exclude`

keywords to suggestions under YAML service definition.

Ref. https://github.com/symfony/dependency-injection/blob/6b12d5bcd1e2f1cc9507cea6181787d642ec46b5/Loader/YamlFileLoader.php#L43-L108