### PR TITLE
Fixed #1716: Deprecated LineMarkerInfo constructor usage

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/ControllerMethodLineMarkerProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/ControllerMethodLineMarkerProvider.java
@@ -82,10 +82,10 @@ public class ControllerMethodLineMarkerProvider implements LineMarkerProvider {
             psiElement,
             psiElement.getTextRange(),
             Symfony2Icons.SYMFONY_LINE_MARKER,
-            6,
             new ConstantFunction<>("Related Files"),
             new RelatedPopupGotoLineMarker.NavigationHandler(gotoRelatedItems),
-            GutterIconRenderer.Alignment.RIGHT
+            GutterIconRenderer.Alignment.RIGHT,
+            () -> "Go to related files"
         );
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigLineMarkerProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigLineMarkerProvider.java
@@ -223,10 +223,10 @@ public class TwigLineMarkerProvider implements LineMarkerProvider {
             ).withIcon(TwigIcons.TwigFileIcon, Symfony2Icons.TWIG_LINE_OVERWRITE));
         }
 
-        return getRelatedPopover("Overwrites", "Overwrite", twigFile, gotoRelatedItems, Symfony2Icons.TWIG_LINE_OVERWRITE);
+        return getRelatedPopover("Overwrites", "Overwrite", twigFile, gotoRelatedItems, Symfony2Icons.TWIG_LINE_OVERWRITE, "Go to the overwritten template");
     }
 
-    private LineMarkerInfo<?> getRelatedPopover(String singleItemTitle, String singleItemTooltipPrefix, PsiElement lineMarkerTarget, List<GotoRelatedItem> gotoRelatedItems, Icon icon) {
+    private LineMarkerInfo<?> getRelatedPopover(String singleItemTitle, String singleItemTooltipPrefix, PsiElement lineMarkerTarget, List<GotoRelatedItem> gotoRelatedItems, Icon icon, String accessibleName) {
 
         // single item has no popup
         String title = singleItemTitle;
@@ -241,10 +241,10 @@ public class TwigLineMarkerProvider implements LineMarkerProvider {
             lineMarkerTarget,
             lineMarkerTarget.getTextRange(),
             icon,
-            6,
             new ConstantFunction<>(title),
             new RelatedPopupGotoLineMarker.NavigationHandler(gotoRelatedItems),
-            GutterIconRenderer.Alignment.RIGHT
+            GutterIconRenderer.Alignment.RIGHT,
+            () -> accessibleName
         );
     }
 


### PR DESCRIPTION
Replaced deprecated 

`LineMarkerInfo(PsiElement, TextRange, Icon, int, Function, GutterIconNavigationHandler<T>, GutterIconRenderer.Alignment)` 

constructor usages with

`LineMarkerInfo(PsiElement, TextRange, Icon, Function, GutterIconNavigationHandler, GutterIconRenderer.Alignment, Supplier)`

as javadoc suggest.