### PR TITLE
Adding a linemarker to php route config

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/PhpLineMarkerProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/PhpLineMarkerProvider.java
@@ -1,0 +1,65 @@
+package fr.adrienbrault.idea.symfony2plugin.routing;
+
+import com.intellij.codeInsight.daemon.LineMarkerInfo;
+import com.intellij.codeInsight.daemon.LineMarkerProvider;
+import com.intellij.codeInsight.daemon.RelatedItemLineMarkerInfo;
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.jetbrains.php.lang.psi.PhpFile;
+import com.jetbrains.php.lang.psi.elements.*;
+import fr.adrienbrault.idea.symfony2plugin.Symfony2Icons;
+import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
+import fr.adrienbrault.idea.symfony2plugin.util.resource.FileResourceUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class PhpLineMarkerProvider implements LineMarkerProvider {
+    @Nullable
+    @Override
+    public LineMarkerInfo<?> getLineMarkerInfo(@NotNull PsiElement psiElement) {
+        return null;
+    }
+
+    @Override
+    public void collectSlowLineMarkers(@NotNull List<? extends PsiElement> psiElements, @NotNull Collection<? super LineMarkerInfo<?>> lineMarkerInfos) {
+        if(psiElements.size() == 0 || !Symfony2ProjectComponent.isEnabled(psiElements.get(0))) {
+            return;
+        }
+
+        for(PsiElement psiElement : psiElements) {
+            attachRouteActions(lineMarkerInfos, psiElement);
+
+            if(psiElement instanceof PhpFile) {
+                RelatedItemLineMarkerInfo<PsiElement> lineMarker = FileResourceUtil.getFileImplementsLineMarker((PsiFile) psiElement);
+                if(lineMarker != null) {
+                    lineMarkerInfos.add(lineMarker);
+                }
+            }
+        }
+    }
+
+    private void attachRouteActions(@NotNull Collection<? super LineMarkerInfo<?>> lineMarkerInfos, @NotNull PsiElement psiElement) {
+        if (!(psiElement instanceof FunctionReference)) {
+            return;
+        }
+
+        MethodReference methodCall = (MethodReference) psiElement;
+        String controllerMethod = RouteHelper.getPhpController(methodCall);
+
+        PsiElement[] methods = RouteHelper.getMethodsOnControllerShortcut(psiElement.getProject(), controllerMethod);
+        if(methods.length > 0) {
+            NavigationGutterIconBuilder<PsiElement> builder = NavigationGutterIconBuilder.create(Symfony2Icons.TWIG_CONTROLLER_LINE_MARKER).
+                    setTargets(methods).
+                    setTooltipText("Navigate to action");
+
+            lineMarkerInfos.add(builder.createLineMarkerInfo(methodCall.getParameters()[0].getFirstChild()));
+        }
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/RouteHelper.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/RouteHelper.java
@@ -835,6 +835,34 @@ public class RouteHelper {
         return null;
     }
 
+    /**
+     * Find controller definition in php function call.
+     * $routes->controller('FooController:method');
+     */
+    @Nullable
+    public static String getPhpController(@Nullable MethodReference methodCall) {
+        if (methodCall == null || !methodCall.getName().equals("controller")) {
+            return null;
+        }
+
+        PhpExpression expression = methodCall;
+        while(expression instanceof MethodReference) {
+            expression = (PhpExpression) expression.getFirstChild();
+        }
+
+        var expr = expression.getInferredType();
+
+        if (!"\\Symfony\\Component\\Routing\\Loader\\Configurator\\RoutingConfigurator".equals(expr.toString())) {
+            return null;
+        }
+
+        PsiElement parameter = methodCall.getParameters()[0];
+        if (parameter instanceof StringLiteralExpression) {
+            return ((StringLiteralExpression) parameter).getContents();
+        }
+        return null;
+    }
+
     @Nullable
     public static PsiElement getXmlRouteNameTarget(@NotNull XmlFile psiFile,@NotNull String routeName) {
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -227,6 +227,7 @@
         <codeInsight.lineMarkerProvider language="Twig" implementationClass="fr.adrienbrault.idea.symfony2plugin.templating.TwigLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="yaml" implementationClass="fr.adrienbrault.idea.symfony2plugin.routing.YamlLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="XML" implementationClass="fr.adrienbrault.idea.symfony2plugin.routing.XmlLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="PHP" implementationClass="fr.adrienbrault.idea.symfony2plugin.routing.PhpLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="XML" implementationClass="fr.adrienbrault.idea.symfony2plugin.dic.linemarker.XmlLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="yaml" implementationClass="fr.adrienbrault.idea.symfony2plugin.dic.linemarker.YamlLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="yaml" implementationClass="fr.adrienbrault.idea.symfony2plugin.config.ConfigLineMarkerProvider"/>

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/routing/PhpLineMarkerProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/routing/PhpLineMarkerProviderTest.java
@@ -1,0 +1,42 @@
+package fr.adrienbrault.idea.symfony2plugin.tests.routing;
+
+import com.intellij.patterns.XmlPatterns;
+import com.intellij.psi.PsiFile;
+import com.jetbrains.php.lang.PhpFileType;
+import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ *
+ * @see fr.adrienbrault.idea.symfony2plugin.routing.PhpLineMarkerProvider
+ */
+public class PhpLineMarkerProviderTest extends SymfonyLightCodeInsightFixtureTestCase {
+
+    public void setUp() throws Exception {
+        super.setUp();
+
+        myFixture.copyFileToProject("BundleScopeLineMarkerProvider.php");
+        myFixture.copyFileToProject("XmlLineMarkerProvider.php");
+    }
+
+    protected String getTestDataPath() {
+        return "src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/routing/fixtures";
+    }
+
+    public void testThatRouteLineMarkerForControllerIsGiven() {
+        assertLineMarker(
+                myFixture.configureByText(
+                PhpFileType.INSTANCE,
+                "<?php\n" +
+                        "use Symfony\\Component\\Routing\\Loader\\Configurator\\RoutingConfigurator;\n" +
+                        "\n" +
+                        "return function(RoutingConfigurator $routes) {\n" +
+                        "    $routes->add('xml_route', '/xml')\n" +
+                        "        ->controller('Foo\\\\Bar')\n" +
+                        "    ;\n" +
+                        "};"
+                ),
+                new LineMarker.ToolTipEqualsAssert("Navigate to action")
+        );
+    }
+}


### PR DESCRIPTION
As mentioned in #1042 the plugin doesn't yet support php. This merge request adds a reference marker to the php controller in the php like so:
![image](https://user-images.githubusercontent.com/14860264/147767826-609c4f6b-9b3c-4d48-8776-2c32aa70cfc8.png)

This is my first real Java application and plugin I contributed to. So feel free point out the rookie mistakes I made.