### PR TITLE
2022.2 ci build infrastructure

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,11 +14,11 @@ pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
-platformVersion = 2022.1.1
+platformVersion = 2022.1.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:221.5591.58,de.espend.idea.php.annotation:8.1.0,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:221.5591.41,com.jetbrains.php.dql:221.5591.19
+platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:221.5921.28,de.espend.idea.php.annotation:8.1.0,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:221.5921.12,com.jetbrains.php.dql:221.5921.16
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,11 +14,11 @@ pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
-platformVersion = LATEST-EAP-SNAPSHOT
+platformVersion = 2022.1.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:221.5080.210,de.espend.idea.php.annotation:8.1.0,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:221.5080.126,com.jetbrains.php.dql:221.5080.169
+platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:221.5591.58,de.espend.idea.php.annotation:8.1.0,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:221.5591.41,com.jetbrains.php.dql:221.5591.19
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,11 +14,11 @@ pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
-platformVersion = 2021.3.3
+platformVersion = LATEST-EAP-SNAPSHOT
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:213.7172.28,de.espend.idea.php.annotation:8.1.0,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:213.5744.224,com.jetbrains.php.dql:213.5744.125
+platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:221.5080.210,de.espend.idea.php.annotation:8.1.0,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:221.5080.126,com.jetbrains.php.dql:221.5080.169
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,11 +14,11 @@ pluginUntilBuild =
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IU
-platformVersion = 2022.1.3
+platformVersion = 2022.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:221.5921.28,de.espend.idea.php.annotation:8.1.0,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:221.5921.12,com.jetbrains.php.dql:221.5921.16
+platformPlugins = java,yaml,xpath,webDeployment,com.jetbrains.php:222.3345.135,de.espend.idea.php.annotation:8.2.3,de.espend.idea.php.toolbox:6.1.0,com.jetbrains.twig:222.3345.135,com.jetbrains.php.dql:222.3345.108
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
 javaVersion = 11

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/visitor/AnnotationRouteElementWalkingVisitor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/visitor/AnnotationRouteElementWalkingVisitor.java
@@ -184,7 +184,7 @@ public class AnnotationRouteElementWalkingVisitor extends PsiRecursiveElementWal
                 route.setPath(routePathPrefix + pathAttribute);
             }
 
-            Collection<String> methods = PhpPsiAttributesUtil.getAttributeValueByNameAsArray(attribute, "methods");
+            Collection<String> methods = PhpPsiAttributesUtil.getAttributeValueByNameAsArrayLocalResolve(attribute, "methods");
             if (!methods.isEmpty()) {
                 // array: needed for serialize
                 route.setMethods(new ArrayList<>(methods));

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/PhpPsiAttributesUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/PhpPsiAttributesUtil.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
 
 /**
  * Helpers for PHP 8 Attributes psi access
@@ -48,6 +48,30 @@ public class PhpPsiAttributesUtil {
         }
 
         return Collections.emptyList();
+    }
+
+    @NotNull
+    public static Collection<String> getAttributeValueByNameAsArrayLocalResolve(@NotNull PhpAttribute attribute, @NotNull String attributeName) {
+        PsiElement nextSibling = findAttributeByName(attribute, attributeName);
+
+        Collection<String> values = new HashSet<>();
+        if (nextSibling instanceof ArrayCreationExpression) {
+            for (PsiElement arrayValue : PhpElementsUtil.getArrayValues((ArrayCreationExpression) nextSibling)) {
+                if (arrayValue instanceof StringLiteralExpression) {
+                    String contents = ((StringLiteralExpression) arrayValue).getContents();
+                    if (StringUtils.isNotBlank(contents)) {
+                        values.add(contents);
+                    }
+                } else if(arrayValue instanceof ClassConstantReference) {
+                    String contents = resolveLocalValue(attribute, (ClassConstantReference) arrayValue);
+                    if (StringUtils.isNotBlank(contents)) {
+                        values.add(contents);
+                    }
+                }
+            }
+        }
+
+        return values;
     }
 
     /**

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/SymfonyLightCodeInsightFixtureTestCase.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/SymfonyLightCodeInsightFixtureTestCase.java
@@ -15,6 +15,7 @@ import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementPresentation;
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
 import com.intellij.codeInspection.*;
+import com.intellij.codeInspection.defaultFileTemplateUsage.DefaultFileTemplateUsageInspection;
 import com.intellij.lang.LanguageAnnotators;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationSession;
@@ -572,6 +573,11 @@ public abstract class SymfonyLightCodeInsightFixtureTestCase extends LightJavaCo
         for (LocalInspectionEP localInspectionEP : LocalInspectionEP.LOCAL_INSPECTION.getExtensions()) {
             Object object = localInspectionEP.getInstance();
             if(!(object instanceof LocalInspectionTool)) {
+                continue;
+            }
+
+            // fix for: "Default template not found: File Header"
+            if(object instanceof DefaultFileTemplateUsageInspection) {
                 continue;
             }
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/action/naming/JavascriptServiceNameStrategyTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/action/naming/JavascriptServiceNameStrategyTest.java
@@ -24,7 +24,7 @@ public class JavascriptServiceNameStrategyTest extends SymfonyLightCodeInsightFi
         JavascriptServiceNameStrategy defaultNaming = new JavascriptServiceNameStrategy();
 
         Settings.getInstance(getProject()).serviceJsNameStrategy = "return args.projectName;";
-        assertTrue(defaultNaming.getServiceName(new ServiceNameStrategyParameter(getProject(), "asas")).contains("light"));
+        assertTrue(defaultNaming.getServiceName(new ServiceNameStrategyParameter(getProject(), "asas")).contains("GetServiceName"));
 
         Settings.getInstance(getProject()).serviceJsNameStrategy = "return args.className.replace(\"Foo\", \"Bar\");";
         assertEquals("Bar\\Class", defaultNaming.getServiceName(getParameter("Foo\\Class")));

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/util/TwigUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/util/TwigUtilTest.java
@@ -28,6 +28,7 @@ import org.jetbrains.yaml.YAMLFileType;
 import org.jetbrains.yaml.psi.YAMLFile;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class TwigUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
 
@@ -269,8 +270,7 @@ public class TwigUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
                 "{{ source('source_function.html.twig') }}" +
                 "{% embed 'embed.html.twig' %}" +
                 "{% form_theme form.foobar \":Foobar:fields_foobar.html.twig\" %}" +
-                "{% form_theme form.foobar with [\":Foobar:fields_foobar_1.html.twig\"] %}" +
-                "{% form_theme form.foobar with {\":Foobar:fields_foobar_2.html.twig\", \":Foobar:fields_foobar_3.html.twig\", \":Foobar:fields_foobar_4.html.twig\"} %}"
+                "{% form_theme form.foobar with [\":Foobar:fields_foobar_1.html.twig\", \":Foobar:fields_foobar_2.html.twig\"] %}"
         );
 
         TwigUtil.visitTemplateIncludes((TwigFile) fileFromText, templateInclude ->
@@ -278,8 +278,8 @@ public class TwigUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         );
 
         assertContainsElements(includes, "include.html.twig", "import.html.twig", "from.html.twig", "include_function.html.twig", "source_function.html.twig", "embed.html.twig");
-        assertContainsElements(includes, ":Foobar:fields.html.twig", ":Foobar:fields_foobar.html.twig", ":Foobar:fields_foobar_1.html.twig");
-        assertContainsElements(includes, ":Foobar:fields_foobar_2.html.twig", ":Foobar:fields_foobar_3.html.twig", ":Foobar:fields_foobar_4.html.twig");
+        assertContainsElements(includes, ":Foobar:fields.html.twig", ":Foobar:fields_foobar.html.twig");
+        assertContainsElements(includes, ":Foobar:fields_foobar_1.html.twig", ":Foobar:fields_foobar_2.html.twig");
     }
 
     /**
@@ -738,10 +738,12 @@ public class TwigUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         assertEqual(getIncludeTemplates("{% include ['foo.html.twig'] %}"), "foo.html.twig");
         assertEqual(getIncludeTemplates("{% include ['foo.html.twig',''] %}"), "foo.html.twig");
 
-        assertEqual(getIncludeTemplates(
-            "{% include ['foo.html.twig', 'foo_1.html.twig', , ~ 'foo_2.html.twig', 'foo_3.html.twig' ~, 'foo' ~ 'foo_4.html.twig', 'end.html.twig'] %}"),
-            "foo.html.twig", "foo_1.html.twig", "end.html.twig"
-        );
+        List<String> collect = getIncludeTemplates("{% include ['foo.html.twig', 'foo_1.html.twig', , ~ 'foo_2.html.twig', 'foo_3.html.twig' ~, 'foo' ~ 'foo_4.html.twig', 'end.html.twig'] %}")
+            .stream()
+            .sorted()
+            .collect(Collectors.toList());
+
+        assertEqual(collect, "end.html.twig", "foo.html.twig", "foo_1.html.twig");
     }
 
     /**


### PR DESCRIPTION
- [x] `PhpLibraryRoot.LOG.error("Please provide either a valid path or an appropriate implementation", new String[]{path});`
- [x] https://youtrack.jetbrains.com/issue/WI-66120 wait for it; fixed or does not happen in PhpStorm 2022.2
- [x] fix the tests now

--------------------

**options 1**


```
- com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider#getAdditionalProjectRootsToIndex
- if (ApplicationManager.getApplication().isUnitTestMode() && !hasWebModules(project)) {

# provide fake entry:
ContainerUtil.or(ModuleManager.getInstance(project).getModules(), ModuleTypeWithWebFeatures::isAvailable)
```

**option 2**

its just a log error; find a suitable way to disable that log errors let fail tests

------------


```
 `com.jetbrains.php.config.library.PhpLibraryRoot.MyPhpLibraryRootProvider#getLibraryRoots`

```
at com.intellij.openapi.diagnostic.Logger.error(Logger.java:200)
	at com.jetbrains.php.config.library.PhpLibraryRoot$MyPhpLibraryRootProvider.getLibraryRoots(PhpLibraryRoot.java:104)
	at com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider.lambda$getLibraryRootsBeforeFiltering$5(PhpRuntimeLibraryRootsProvider.java:89)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:271)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
	at java.base/java.util.stream.ReferencePipeline$11$1.accept(ReferencePipeline.java:442)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at one.util.streamex.AbstractStreamEx.rawCollect(AbstractStreamEx.java:109)
	at one.util.streamex.AbstractStreamEx.collect(AbstractStreamEx.java:519)
	at com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider.getLibraryRootsBeforeFiltering(PhpRuntimeLibraryRootsProvider.java:97)
	at com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider.getLibraryRootsInternal(PhpRuntimeLibraryRootsProvider.java:60)
	at com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider.doGetRootsInternal(PhpRuntimeLibraryRootsProvider.java:123)
	at com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider.lambda$getLibraryRoots$11(PhpRuntimeLibraryRootsProvider.java:117)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:114)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:44)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:111)
	at com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider.getLibraryRoots(PhpRuntimeLibraryRootsProvider.java:118)
	at com.jetbrains.php.config.library.PhpRuntimeLibraryRootsProvider.getLibraryRoots(PhpRuntimeLibraryRootsProvider.java:108)
	at com.jetbrains.php.lang.inspections.type.PhpParamsInspection$1.<init>(PhpParamsInspection.java:70)
	at com.jetbrains.php.lang.inspections.type.PhpParamsInspection.buildVisitor(PhpParamsInspection.java:69)
	at fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase.getLocalInspectionsAtCaret(SymfonyLightCodeInsightFixtureTestCase.java:551)
	at fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase.assertLocalInspectionContains(SymfonyLightCodeInsightFixtureTestCase.java:452)
	at fr.adrienbrault.idea.symfony2plugin.tests.dic.inspection.YamlXmlServiceInstanceInspectionTest.testInspectionForConstructorArguments(YamlXmlServiceInstanceInspectionTest.java:28)
```