### PR TITLE
#1574 #1834 fix all psi references which are not attached to itself

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/xml/ConstantXmlReference.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/xml/ConstantXmlReference.java
@@ -1,37 +1,34 @@
 package fr.adrienbrault.idea.symfony2plugin.config.xml;
 
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementResolveResult;
 import com.intellij.psi.PsiPolyVariantReferenceBase;
 import com.intellij.psi.ResolveResult;
-import com.intellij.psi.xml.XmlText;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.util.ServiceContainerUtil;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
-class ConstantXmlReference extends PsiPolyVariantReferenceBase<XmlText> {
-    ConstantXmlReference(@NotNull XmlText element) {
+class ConstantXmlReference extends PsiPolyVariantReferenceBase<PsiElement> {
+    private final String value;
+
+    ConstantXmlReference(@NotNull PsiElement element, @NotNull String value) {
         super(element);
+        this.value = value;
     }
 
     @NotNull
     @Override
-    public ResolveResult[] multiResolve(boolean incompleteCode) {
-        String contents = getElement().getValue();
-        if(StringUtils.isBlank(contents)) {
-            return new ResolveResult[0];
-        }
-
+    public ResolveResult @NotNull [] multiResolve(boolean incompleteCode) {
         return PsiElementResolveResult.createResults(
-            ServiceContainerUtil.getTargetsForConstant(getElement().getProject(), contents)
+            ServiceContainerUtil.getTargetsForConstant(getElement().getProject(), value)
         );
     }
 
     @NotNull
     @Override
-    public Object[] getVariants() {
+    public Object @NotNull [] getVariants() {
         return new Object[0];
     }
 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/xml/ParameterXmlReference.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/xml/ParameterXmlReference.java
@@ -4,7 +4,6 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementResolveResult;
 import com.intellij.psi.PsiPolyVariantReferenceBase;
 import com.intellij.psi.ResolveResult;
-import com.intellij.psi.xml.XmlText;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.util.DotEnvUtil;
 import fr.adrienbrault.idea.symfony2plugin.util.dict.ServiceUtil;
 import org.jetbrains.annotations.NotNull;
@@ -16,17 +15,16 @@ import java.util.Collection;
  * @author Daniel Espendiller <daniel@espendiller.net>
  */
 public class ParameterXmlReference extends PsiPolyVariantReferenceBase<PsiElement> {
+    private final String parameterName;
 
-    private String parameterName;
-
-    public ParameterXmlReference(@NotNull XmlText element) {
-        super(element);
-        parameterName = element.getValue();
+    public ParameterXmlReference(@NotNull PsiElement psiElement, @NotNull String parameterName) {
+        super(psiElement);
+        this.parameterName = parameterName;
     }
 
     @NotNull
     @Override
-    public ResolveResult[] multiResolve(boolean incompleteCode) {
+    public ResolveResult @NotNull [] multiResolve(boolean incompleteCode) {
         Collection<PsiElement> targets = new ArrayList<>();
 
         targets.addAll(
@@ -40,7 +38,7 @@ public class ParameterXmlReference extends PsiPolyVariantReferenceBase<PsiElemen
 
     @NotNull
     @Override
-    public Object[] getVariants() {
+    public Object @NotNull [] getVariants() {
         return new Object[0];
     }
 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/xml/XmlReferenceContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/xml/XmlReferenceContributor.java
@@ -52,7 +52,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
             new PsiReferenceProvider() {
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
                     if(!Symfony2ProjectComponent.isEnabled(psiElement)) {
                         return new PsiReference[0];
                     }
@@ -88,7 +88,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
             new PsiReferenceProvider() {
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
 
                     if(!Symfony2ProjectComponent.isEnabled(psiElement)) {
                         return new PsiReference[0];
@@ -108,7 +108,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
             new PsiReferenceProvider() {
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
 
                     if(!Symfony2ProjectComponent.isEnabled(psiElement)) {
                         return new PsiReference[0];
@@ -119,7 +119,12 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
                         return new PsiReference[0];
                     }
 
-                    return new PsiReference[]{ new ParameterXmlReference(((XmlText) parent)) };
+                    String value = ((XmlText) parent).getValue();
+                    if (StringUtils.isBlank(value)) {
+                        return new PsiReference[0];
+                    }
+
+                    return new PsiReference[]{ new ParameterXmlReference(psiElement, value) };
                 }
             }
         );
@@ -130,7 +135,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
             new PsiReferenceProvider() {
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
                     if(!Symfony2ProjectComponent.isEnabled(psiElement)) {
                         return new PsiReference[0];
                     }
@@ -140,12 +145,12 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
                         return new PsiReference[0];
                     }
 
-                    String text = parent.getText();
-                    if(StringUtils.isBlank(text)) {
+                    String value = ((XmlText) parent).getValue();
+                    if (StringUtils.isBlank(value)) {
                         return new PsiReference[0];
                     }
 
-                    return new PsiReference[]{ new ConstantXmlReference(((XmlText) parent)) };
+                    return new PsiReference[]{ new ConstantXmlReference(psiElement, value) };
                 }
             }
         );
@@ -163,7 +168,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
                     if(!Symfony2ProjectComponent.isEnabled(element)) {
                         return new PsiReference[0];
@@ -236,7 +241,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
                     if(!Symfony2ProjectComponent.isEnabled(element)) {
                         return new PsiReference[0];
@@ -262,7 +267,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
 
                     if(!Symfony2ProjectComponent.isEnabled(element)) {
                         return new PsiReference[0];
@@ -281,7 +286,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
     private static class ClassPsiReferenceProvider extends PsiReferenceProvider {
         @NotNull
         @Override
-        public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+        public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
             if(!Symfony2ProjectComponent.isEnabled(psiElement) || !(psiElement instanceof XmlAttributeValue)) {
                 return new PsiReference[0];
             }
@@ -300,7 +305,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
     private static class ClassAsIdPsiReferenceProvider extends PsiReferenceProvider {
         @NotNull
         @Override
-        public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+        public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
             if(!Symfony2ProjectComponent.isEnabled(psiElement) || !(psiElement instanceof XmlAttributeValue)) {
                 return new PsiReference[0];
             }
@@ -325,10 +330,10 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
     /**
      * <factory service="foo" method="create"/>
      */
-    private class FactoryServiceMethodPsiReferenceProvider extends PsiReferenceProvider {
+    private static class FactoryServiceMethodPsiReferenceProvider extends PsiReferenceProvider {
         @NotNull
         @Override
-        public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext context) {
+        public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext context) {
             if(!Symfony2ProjectComponent.isEnabled(psiElement) || !(psiElement instanceof XmlAttributeValue)) {
                 return new PsiReference[0];
             }
@@ -354,10 +359,10 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
         }
     }
 
-    private class ClassMethodReferenceProvider extends PsiReferenceProvider {
+    private static class ClassMethodReferenceProvider extends PsiReferenceProvider {
         @NotNull
         @Override
-        public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext context) {
+        public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext context) {
 
             if(!Symfony2ProjectComponent.isEnabled(psiElement)) {
                 return new PsiReference[0];
@@ -388,7 +393,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
         @NotNull
         @Override
-        public ResolveResult[] multiResolve(boolean b) {
+        public ResolveResult @NotNull [] multiResolve(boolean b) {
             String value = this.psiElement.getValue();
 
 
@@ -406,7 +411,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
         @NotNull
         @Override
-        public Object[] getVariants() {
+        public Object @NotNull [] getVariants() {
             return new Object[0];
         }
 
@@ -427,14 +432,14 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
         @NotNull
         @Override
-        public ResolveResult[] multiResolve(boolean b) {
+        public ResolveResult @NotNull [] multiResolve(boolean b) {
             String value = this.psiElement.getValue();
             return PsiElementResolveResult.createResults(ServiceUtil.getServiceClassTargets(getElement().getProject(), value));
         }
 
         @NotNull
         @Override
-        public Object[] getVariants() {
+        public Object @NotNull [] getVariants() {
             return new Object[0];
         }
     }
@@ -442,10 +447,10 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
     /**
      * <factory class="FooBar" method="cre<caret>ate"/>
      */
-    private class FactoryClassMethodPsiReferenceProvider extends PsiReferenceProvider {
+    private static class FactoryClassMethodPsiReferenceProvider extends PsiReferenceProvider {
         @NotNull
         @Override
-        public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+        public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
             if(!Symfony2ProjectComponent.isEnabled(psiElement) || !(psiElement instanceof XmlAttributeValue)) {
                 return new PsiReference[0];
             }
@@ -471,7 +476,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
         }
     }
 
-    private class ChainPsiReferenceProvider extends PsiReferenceProvider {
+    private static class ChainPsiReferenceProvider extends PsiReferenceProvider {
         @NotNull
         private final PsiReferenceProvider[] psiReferenceProviders;
 
@@ -481,18 +486,18 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
         @NotNull
         @Override
-        public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+        public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
             Collection<PsiReference> psiReferences = new ArrayList<>();
 
             for (PsiReferenceProvider provider : this.psiReferenceProviders) {
                 ContainerUtil.addAll(psiReferences, provider.getReferencesByElement(psiElement, processingContext));
             }
 
-            return psiReferences.toArray(new PsiReference[psiReferences.size()]);
+            return psiReferences.toArray(new PsiReference[0]);
         }
     }
 
-    private class ClassMethodStringPsiReference extends PsiPolyVariantReferenceBase<PsiElement> {
+    private static class ClassMethodStringPsiReference extends PsiPolyVariantReferenceBase<PsiElement> {
         @NotNull
         private final String aClass;
 
@@ -507,7 +512,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
         @NotNull
         @Override
-        public ResolveResult[] multiResolve(boolean b) {
+        public ResolveResult @NotNull [] multiResolve(boolean b) {
             Method classMethod = PhpElementsUtil.getClassMethod(getElement().getProject(), aClass, method);
             if(classMethod == null) {
                 return new ResolveResult[0];
@@ -518,7 +523,7 @@ public class XmlReferenceContributor extends PsiReferenceContributor {
 
         @NotNull
         @Override
-        public Object[] getVariants() {
+        public Object @NotNull [] getVariants() {
             return new Object[0];
         }
     }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlReferenceContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/config/yaml/YamlReferenceContributor.java
@@ -21,7 +21,7 @@ public class YamlReferenceContributor extends PsiReferenceContributor {
             new PsiReferenceProvider() {
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
                     if (!Symfony2ProjectComponent.isEnabled(element)) {
                         return PsiReference.EMPTY_ARRAY;
                     }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/RouteXmlReferenceContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/RouteXmlReferenceContributor.java
@@ -22,7 +22,7 @@ public class RouteXmlReferenceContributor extends PsiReferenceContributor {
             new PsiReferenceProvider() {
                 @NotNull
                 @Override
-                public PsiReference[] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
+                public PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement psiElement, @NotNull ProcessingContext processingContext) {
                     if(!Symfony2ProjectComponent.isEnabled(psiElement)) {
                         return new PsiReference[0];
                     }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/xml/XmlReferenceContributorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/config/xml/XmlReferenceContributorTest.java
@@ -81,12 +81,6 @@ public class XmlReferenceContributorTest extends SymfonyLightCodeInsightFixtureT
     }
 
     public void testThatArgumentConstantProvidesReferences() {
-        // skip for 2019.x build
-        // reference XmlText:null was created for XmlToken:XML_DATA_CHARACTERS but target XmlText, provider
-        if(true) {
-            return;
-        }
-
         assertReferenceMatch(XmlFileType.INSTANCE, "" +
                 "<?xml version=\"1.0\"?>\n" +
                 "<container>\n" +
@@ -113,12 +107,6 @@ public class XmlReferenceContributorTest extends SymfonyLightCodeInsightFixtureT
     }
 
     public void testEnvironmentParameter() {
-        // skip for 2019.x build
-        // reference XmlText:null was created for XmlToken:XML_DATA_CHARACTERS but target XmlText, provider
-        if(true) {
-            return;
-        }
-
         assertReferenceMatch(XmlFileType.INSTANCE, "" +
                 "<?xml version=\"1.0\"?>\n" +
                 "<container>\n" +


### PR DESCRIPTION
```
java.lang.AssertionError: reference fr.adrienbrault.idea.symfony2plugin.config.xml.ParameterXmlReference(XmlText:null) was created for XmlToken:XML_DATA_CHARACTERS but target XmlText, provider fr.adrienbrault.idea.symfony2plugin.config.xml.XmlReferenceContributor$3@37527615
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistryImpl.assertReferenceUnderlyingElement(ReferenceProvidersRegistryImpl.java:191)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistryImpl.mapNotEmptyReferencesFromProviders(ReferenceProvidersRegistryImpl.java:165)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistryImpl.doGetReferencesFromProviders(ReferenceProvidersRegistryImpl.java:141)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry.lambda$getReferencesFromProviders$0(ReferenceProvidersRegistry.java:39)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:39)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:227)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:42)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:227)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:114)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:44)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:68)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:228)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:28)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:72)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:121)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry.getReferencesFromProviders(ReferenceProvidersRegistry.java:38)
	at com.intellij.psi.impl.source.xml.XmlTokenImpl.getReferences(XmlTokenImpl.java:63)
	at com.intellij.psi.impl.source.xml.XmlTokenImpl.getReferences(XmlTokenImpl.java:54)
	at com.intellij.codeInsight.highlighting.HyperlinkAnnotator.annotate(HyperlinkAnnotator.java:42)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.runAnnotators(DefaultHighlightVisitor.java:131)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.visit(DefaultHighlightVisitor.java:108)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.runVisitors(GeneralHighlightingPass.java:344)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$collectHighlights$7(GeneralHighlightingPass.java:283)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:303)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$analyzeByVisitors$8(GeneralHighlightingPass.java:306)
	at com.intellij.codeInsight.daemon.impl.analysis.XmlHighlightVisitor.analyze(XmlHighlightVisitor.java:606)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:306)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$analyzeByVisitors$8(GeneralHighlightingPass.java:306)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.analyze(DefaultHighlightVisitor.java:93)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:306)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectHighlights(GeneralHighlightingPass.java:274)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectInformationWithProgress(GeneralHighlightingPass.java:219)
	at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:84)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:56)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:414)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1084)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:407)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:624)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:698)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:646)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:623)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:66)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:406)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:382)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:174)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:181)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:380)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:184)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```