### PR TITLE
#1509 catch xlf parser exception

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
@@ -334,7 +334,7 @@ public class TranslationUtil {
         try {
             DocumentBuilder documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             document = documentBuilder.parse(content);
-        } catch (ParserConfigurationException | SAXException | IOException e) {
+        } catch (ParserConfigurationException | SAXException | ArrayIndexOutOfBoundsException | IOException e) {
             return;
         }
 


### PR DESCRIPTION
java.lang.ArrayIndexOutOfBoundsException: Index -1266568392 out of bounds for length -2073969448
at org.apache.xerces.impl.dtd.XMLDTDValidator.reset(Unknown Source)