### PR TITLE
Fixed bad links to jetbrains plugin marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Since PhpStorm 2022.1 is plugin is marked a "Freemium".
 *   Non-free features are flagged with _[paid]_ inside the [CHANGELOG](https://github.com/Haehnchen/idea-php-symfony2-plugin/blob/master/CHANGELOG.md)
 *   There is ~15min grace period after project open where all features are available
 
-_A license can be bought at [JetBrains Marketplace](https://www.jetbrains.com/shop/quote?item=C%3AN%3APSYMFONYPLUGIN%3AY). Free Discount Code generator for open source contributions are planned._
+_A license can be bought at [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/7219-symfony-support/pricing). Free Discount Code generator for open source contributions are planned._
 
 Version
 ---------------------

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
 
 <br/>
 
-<a href="https://espend.de/phpstorm/plugin/symfony">Project Page / Documentation</a> | <a href="https://www.paypal.me/DanielEspendiller">Donate</a> | <a href="https://www.jetbrains.com/shop/checkout?code=d3rturdz914s2wh9px4f6vp8x&requestQuote=true">Buy License</a>
+<a href="https://espend.de/phpstorm/plugin/symfony">Project Page / Documentation</a> | <a href="https://www.paypal.me/DanielEspendiller">Donate</a> | <a href="https://plugins.jetbrains.com/plugin/7219-symfony-support/pricing">Buy License</a>
 
 <h2>Install</h2>
 


### PR DESCRIPTION
Hi there, just wanted to buy a license for PHPStorm and had several small problems:

![image](https://user-images.githubusercontent.com/681514/169788299-e1b29f2c-43c9-4891-bdb8-7afa834a3c7b.png)

Leads to a 404 page. I then followed the linked mentioned below

![image](https://user-images.githubusercontent.com/681514/169788469-6e4ec410-d608-4692-8ff4-e6d1e52fd15d.png)

and completed the, at least to me, unknown flow which ended in me creating a team account in addition to my personal account, which the license was assigned to. Had it reversed via support.

This PR corrects the link to the proper market place entry point that everyone should know. It also gives the correct flow to decide if you want a personal license or a organization one.

I'm not sure which of the files is responsible for the view inside the plugin overview, so I corrected all links I could find.
