### PR TITLE
fix: "Template not found: PHP Getter Method"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.6.20"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.5.2"
+    id("org.jetbrains.intellij") version "1.10.0"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // Gradle Qodana Plugin

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -76,7 +76,7 @@
     <li>Several stub indexer to provide some live generation provider in replacement for compiled container</li>
     <li>Linemarker and "Related File" to provide possible goto targets and controller action</li>
     <li>Search Everywhere support and custom search for only Symfony related Symbols "Navigate > Symfony Symbol"</li>
-    <li>Bridge for <a href="http://plugins.jetbrains.com/plugin/7320">PHP Annotations</a> to support annotation related stuff</li>
+    <li>Bridge for <a href="https://plugins.jetbrains.com/plugin/7320">PHP Annotations</a> to support annotation related stuff</li>
     <li>Dotenv and Docker environments variable extraction for DIC parameter</li>
 </ul>
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/IncompletePropertyServiceInjectionContributorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/completion/IncompletePropertyServiceInjectionContributorTest.java
@@ -309,7 +309,17 @@ public class IncompletePropertyServiceInjectionContributorTest extends SymfonyLi
         String text = fromText.getText();
         assertTrue(text.contains("public function __construct(private readonly \\DateTime $d,private readonly UrlGeneratorInterface $router)"));
 
-        // test case for missing "__construct" not possible: "Template not found: PHP Getter Method" exception
+        PhpClass fromText2 = PhpPsiElementFactory.createFromText(getProject(), PhpClass.class, "<?php\n" +
+            "\n" +
+            "class Foobar\n" +
+            "{\n" +
+            "}"
+        );
+
+        IncompletePropertyServiceInjectionContributor.appendPropertyInjection(fromText2, "router", "\\Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface");
+
+        String text2 = fromText2.getText();
+        assertTrue(text2.contains("public function __construct(UrlGeneratorInterface $router)"));
     }
 
     public void testInjectionService() {


### PR DESCRIPTION
https://github.com/JetBrains/gradle-intellij-plugin/issues/1094 via upgrading

 "org.jetbrains.intellij" to "1.10.0"