### PR TITLE
Speed up indexing: replace recursive visitors with linear scans

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/EntityHelper.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/EntityHelper.java
@@ -92,7 +92,7 @@ public class EntityHelper {
         if(docAnnotation != null) {
             // search for repositoryClass="Foo\Bar\RegisterRepository"; repositoryClass=Foo\Bar\RegisterRepository::class
             // @MongoDB\Document; @ORM\Entity
-            Collection<Pair<String, String>> classRepositoryPair = DoctrineUtil.getClassRepositoryPair(docAnnotation);
+            Collection<Pair<String, String>> classRepositoryPair = DoctrineUtil.extractAnnotations(phpClass, docAnnotation);
             if (!classRepositoryPair.isEmpty()) {
                 Pair<String, String> next = classRepositoryPair.iterator().next();
                 if (next.getSecond() != null) {


### PR DESCRIPTION
Hi, PhpStorm here! We're working on improving indexing performance and saw an optimization opportunity. It's generally recommended to avoid using recursive visitors, since they traverse whole trees which might be very deep. In case of Symfony Plugin we can replace them with other techniques like traversing only needed elements and/or ControlFlow (which is a linear data structure and contains less nodes than trees)

This change results into at least 10% indexing speed up on our internal tests.