### PR TITLE
Use PsiReference list to determine if "missing" inspections apply

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/inspection/MissingServiceInspection.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/inspection/MissingServiceInspection.java
@@ -10,6 +10,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.config.yaml.YamlElementPatternHelper;
+import fr.adrienbrault.idea.symfony2plugin.dic.ServiceReference;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.util.ServiceContainerUtil;
 import fr.adrienbrault.idea.symfony2plugin.stubs.ContainerCollectionResolver;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
@@ -18,6 +19,8 @@ import fr.adrienbrault.idea.symfony2plugin.util.yaml.YamlHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.YAMLLanguage;
+
+import java.util.Arrays;
 
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
@@ -48,7 +51,7 @@ public class MissingServiceInspection extends LocalInspectionTool {
             if(element.getLanguage() == PhpLanguage.INSTANCE && element instanceof StringLiteralExpression) {
                 // PHP
                 MethodReference methodReference = PsiElementUtils.getMethodReferenceWithFirstStringParameter((StringLiteralExpression) element);
-                if (methodReference != null && PhpElementsUtil.isMethodReferenceInstanceOf(methodReference, ServiceContainerUtil.SERVICE_GET_SIGNATURES)) {
+                if (methodReference != null && Arrays.stream(element.getReferences()).anyMatch(ref -> ref instanceof ServiceReference)) {
                     String serviceName = PhpElementsUtil.getFirstArgumentStringValue(methodReference);
                     if (StringUtils.isNotBlank(serviceName) && !hasService(serviceName)) {
                         holder.registerProblem(element, INSPECTION_MESSAGE, ProblemHighlightType.GENERIC_ERROR_OR_WARNING);

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/inspection/PhpRouteMissingInspection.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/routing/inspection/PhpRouteMissingInspection.java
@@ -6,14 +6,14 @@ import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementVisitor;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
-import fr.adrienbrault.idea.symfony2plugin.routing.PhpRouteReferenceContributor;
 import fr.adrienbrault.idea.symfony2plugin.routing.Route;
 import fr.adrienbrault.idea.symfony2plugin.routing.RouteHelper;
-import fr.adrienbrault.idea.symfony2plugin.util.MethodMatcher;
+import fr.adrienbrault.idea.symfony2plugin.routing.RouteReference;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -43,16 +43,12 @@ public class PhpRouteMissingInspection extends LocalInspectionTool {
     }
 
     private void invoke(@NotNull String routeName, @NotNull final PsiElement element, @NotNull ProblemsHolder holder) {
-        MethodMatcher.MethodMatchParameter methodMatchParameter = new MethodMatcher.StringParameterMatcher(element, 0)
-            .withSignature(PhpRouteReferenceContributor.GENERATOR_SIGNATURES)
-            .match();
-
-        if(methodMatchParameter == null) {
+        if(Arrays.stream(element.getReferences()).noneMatch(ref -> ref instanceof RouteReference)) {
             return;
         }
 
         Collection<Route> route = RouteHelper.getRoute(element.getProject(), routeName);
-        if(route.size() == 0) {
+        if(route.isEmpty()) {
             holder.registerProblem(element, "Symfony: Missing Route", ProblemHighlightType.GENERIC_ERROR_OR_WARNING, new RouteGuessTypoQuickFix(routeName));
         }
     }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/PhpTemplateMissingInspection.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/PhpTemplateMissingInspection.java
@@ -10,7 +10,6 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.ParameterList;
 import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
-import fr.adrienbrault.idea.symfony2plugin.config.SymfonyPhpReferenceContributor;
 import fr.adrienbrault.idea.symfony2plugin.templating.inspection.TemplateCreateByNameLocalQuickFix;
 import fr.adrienbrault.idea.symfony2plugin.templating.inspection.TemplateGuessTypoQuickFix;
 import fr.adrienbrault.idea.symfony2plugin.templating.util.TwigUtil;
@@ -20,6 +19,8 @@ import fr.adrienbrault.idea.symfony2plugin.util.PsiElementUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
 
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
@@ -81,7 +82,7 @@ public class PhpTemplateMissingInspection extends LocalInspectionTool {
             return null;
         }
 
-        if (!PhpElementsUtil.isMethodReferenceInstanceOf((MethodReference) methodReference, SymfonyPhpReferenceContributor.TEMPLATE_SIGNATURES)) {
+        if(Arrays.stream(psiElement.getReferences()).noneMatch(ref -> ref instanceof TemplateReference)) {
             return null;
         }
 


### PR DESCRIPTION
Instead of using static signature lists to check if the route, service, and template "missing" inspections apply, we can instead check if the element's `PsiReference` list contains the relevant reference type. This change allows these inspections to operate in the same contexts as auto-completion, such as when the reference was tagged with a PhpDoc hash (e.g., `#Route`) or configured through the settings panel.

Thanks!

Fixes #2255 