### PR TITLE
Add support for suffix "message" in Constraint properties

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/ConstraintMessageGotoCompletionRegistrar.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/ConstraintMessageGotoCompletionRegistrar.java
@@ -42,7 +42,7 @@ public class ConstraintMessageGotoCompletionRegistrar implements GotoCompletionR
                 .withName(PlatformPatterns.or(
                     PlatformPatterns.string().startsWith("message"),
                     PlatformPatterns.string().endsWith("Message")
-                )
+                ))
             ));
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/ConstraintMessageGotoCompletionRegistrar.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/ConstraintMessageGotoCompletionRegistrar.java
@@ -39,7 +39,10 @@ public class ConstraintMessageGotoCompletionRegistrar implements GotoCompletionR
             PhpTokenTypes.STRING_LITERAL
         )).withParent(PlatformPatterns.psiElement(StringLiteralExpression.class)
             .withParent(PlatformPatterns.psiElement(Field.class)
-                .withName(PlatformPatterns.string().startsWith("message"))
+                .withName(PlatformPatterns.or(
+                    PlatformPatterns.string().startsWith("message"),
+                    PlatformPatterns.string().endsWith("Message")
+                )
             ));
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/annotation/ConstraintMessageAnnotationReferences.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/annotation/ConstraintMessageAnnotationReferences.java
@@ -28,7 +28,7 @@ public class ConstraintMessageAnnotationReferences implements PhpAnnotationRefer
         }
 
         String propertyName = parameter.getPropertyName();
-        if (propertyName == null || !propertyName.startsWith("message")) {
+        if (propertyName == null || (!propertyName.startsWith("message") && !propertyName.endsWith("Message"))) {
             return new PsiReference[0];
         }
 
@@ -47,7 +47,7 @@ public class ConstraintMessageAnnotationReferences implements PhpAnnotationRefer
         }
 
         String propertyName = parameter.getPropertyName();
-        if (propertyName == null || !propertyName.startsWith("message")) {
+        if (propertyName == null || (!propertyName.startsWith("message") && !propertyName.endsWith("Message"))) {
             return;
         }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/translation/dict/TranslationUtil.java
@@ -462,6 +462,7 @@ public class TranslationUtil {
      * class FooConstraint extends \Symfony\Component\Validator\Constraint
      * public $message = 'This value should not be blank.';
      * public $messageFoo = 'This value should not be blank.';
+     * public $fooMessage = 'This value should not be blank.';
      */
     public static boolean isConstraintPropertyField(@NotNull StringLiteralExpression psiElement) {
         PsiElement field = psiElement.getParent();
@@ -469,7 +470,7 @@ public class TranslationUtil {
             PhpClass containingClass = ((Field) field).getContainingClass();
             if (containingClass != null && PhpElementsUtil.isInstanceOf(containingClass, "\\Symfony\\Component\\Validator\\Constraint")) {
                 String name = ((Field) field).getName();
-                return name.startsWith("message");
+                return name.startsWith("message") || name.endsWith("Message");
             }
         }
 


### PR DESCRIPTION
Hi @Haehnchen

The plugin only provide autocompletion for Constraint properties which starts with "message" but it's more common to see the suffix "message".
For instance https://symfony.com/doc/current/reference/constraints/Length.html
has `minMessage` and `maxMessage` property.

I tried to make the change, but I'm not familiar to JAVA, so open to any comment :) 

Thanks a lot for your time and this project.