### PR TITLE
Enhance AsEventListener support

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/SymfonyImplicitUsageProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/SymfonyImplicitUsageProvider.java
@@ -179,6 +179,10 @@ public class SymfonyImplicitUsageProvider implements ImplicitUsageProvider {
     }
 
     private boolean isAsEventListenerMethodPhpAttribute(@NotNull Method method) {
+        if (!method.getAttributes("\\Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener").isEmpty()) {
+            return true;
+        }
+
         PhpClass containingClass = method.getContainingClass();
         if (containingClass == null) {
             return false;

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/SymfonyImplicitUsageProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/SymfonyImplicitUsageProvider.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -209,6 +210,16 @@ public class SymfonyImplicitUsageProvider implements ImplicitUsageProvider {
 
             if (eventAttr == null && methodAttr == null) {
                 methodAttr = "__invoke";
+            }
+
+            if (methodAttr == null) {
+                String snakeCased = Pattern.compile("(?<=\\b|_)[a-z]", Pattern.CASE_INSENSITIVE)
+                        .matcher(eventAttr)
+                        .replaceAll(matchResult -> matchResult.group().toUpperCase());
+
+                methodAttr = "on" + Pattern.compile("[^a-z0-9]", Pattern.CASE_INSENSITIVE)
+                        .matcher(snakeCased)
+                        .replaceAll("");
             }
 
             if (method.getName().equals(methodAttr)) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/SymfonyImplicitUsageProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/codeInsight/SymfonyImplicitUsageProvider.java
@@ -189,14 +189,30 @@ public class SymfonyImplicitUsageProvider implements ImplicitUsageProvider {
         }
 
         for (PhpAttribute attribute : containingClass.getAttributes("\\Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener")) {
+            String methodAttr = null;
+            String eventAttr = null;
             for (PhpAttribute.PhpAttributeArgument argument : attribute.getArguments()) {
-                if ("method".equals(argument.getName()) && argument.getArgument() instanceof PhpExpectedFunctionScalarArgument scalarArgument) {
-                    String value = PsiElementUtils.trimQuote(scalarArgument.getNormalizedValue());
+                if ("method".equals(argument.getName())) {
+                    if (argument.getArgument() instanceof PhpExpectedFunctionScalarArgument scalarArgument) {
+                        methodAttr = PsiElementUtils.trimQuote(scalarArgument.getNormalizedValue());
 
-                    if (method.getName().equals(value)) {
-                        return true;
+                        if (method.getName().equals(methodAttr)) {
+                            return true;
+                        }
+                    }
+                } else if ("event".equals(argument.getName())) {
+                    if (argument.getArgument() instanceof PhpExpectedFunctionScalarArgument scalarArgument) {
+                        eventAttr = PsiElementUtils.trimQuote(scalarArgument.getNormalizedValue());
                     }
                 }
+            }
+
+            if (eventAttr == null && methodAttr == null) {
+                methodAttr = "__invoke";
+            }
+
+            if (method.getName().equals(methodAttr)) {
+                return true;
             }
         }
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
@@ -222,7 +222,7 @@ public class SymfonyImplicitUsageProviderTest extends SymfonyLightCodeInsightFix
     }
 
 
-    public void testEventSubscriberGetAsEventListener() {
+    public void testEventSubscriberGetAsEventListenerOnClass() {
         PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
                 "namespace App\\EventListener;\n" +
                 "\n" +
@@ -242,6 +242,28 @@ public class SymfonyImplicitUsageProviderTest extends SymfonyLightCodeInsightFix
 
         assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onFoo")));
     }
+
+    public void testEventSubscriberGetAsEventListenerOnMethod() {
+        PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
+                "namespace App\\EventListener;\n" +
+                "\n" +
+                "use Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener;\n" +
+                "\n" +
+                "final class MyMultiListener\n" +
+                "{\n" +
+                "    #[AsEventListener]\n" +
+                "    public function onFoo(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "\n" +
+                "}"
+        );
+
+        PhpClass phpClass = PhpElementsUtil.getFirstClassFromFile((PhpFile) psiFile.getContainingFile());
+
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onFoo")));
+    }
+
     public void testTwigExtensionRegisteredAsServiceWithFunctionMethodImplementedIsMarkedUsed() {
         PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
             "\n" +

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
@@ -285,6 +285,48 @@ public class SymfonyImplicitUsageProviderTest extends SymfonyLightCodeInsightFix
         assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("__invoke")));
     }
 
+    public void testEventSubscriberGetAsEventListenerOnClassWithoutMethod() {
+        PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
+                "namespace App\\EventListener;\n" +
+                "\n" +
+                "use Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener;\n" +
+                "\n" +
+                "#[AsEventListener(event: 'bar')]\n" +
+                "final class MyMultiListener\n" +
+                "{\n" +
+                "    public function onBar(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "\n" +
+                "}"
+        );
+
+        PhpClass phpClass = PhpElementsUtil.getFirstClassFromFile((PhpFile) psiFile.getContainingFile());
+
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onBar")));
+    }
+
+    public void testEventSubscriberGetAsEventListenerOnClassWithoutMethodCleanUp() {
+        PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
+                "namespace App\\EventListener;\n" +
+                "\n" +
+                "use Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener;\n" +
+                "\n" +
+                "#[AsEventListener(event: 'foo-bar')]\n" +
+                "final class MyMultiListener\n" +
+                "{\n" +
+                "    public function onFooBar(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "\n" +
+                "}"
+        );
+
+        PhpClass phpClass = PhpElementsUtil.getFirstClassFromFile((PhpFile) psiFile.getContainingFile());
+
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onFooBar")));
+    }
+
     public void testTwigExtensionRegisteredAsServiceWithFunctionMethodImplementedIsMarkedUsed() {
         PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
             "\n" +

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
@@ -264,6 +264,27 @@ public class SymfonyImplicitUsageProviderTest extends SymfonyLightCodeInsightFix
         assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onFoo")));
     }
 
+    public void testEventSubscriberGetAsEventListenerOnClassInvokeWithoutMethod() {
+        PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
+                "namespace App\\EventListener;\n" +
+                "\n" +
+                "use Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener;\n" +
+                "\n" +
+                "#[AsEventListener()]\n" +
+                "final class MyMultiListener\n" +
+                "{\n" +
+                "    public function __invoke(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "\n" +
+                "}"
+        );
+
+        PhpClass phpClass = PhpElementsUtil.getFirstClassFromFile((PhpFile) psiFile.getContainingFile());
+
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("__invoke")));
+    }
+
     public void testTwigExtensionRegisteredAsServiceWithFunctionMethodImplementedIsMarkedUsed() {
         PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
             "\n" +

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/codeInsight/SymfonyImplicitUsageProviderTest.java
@@ -327,6 +327,46 @@ public class SymfonyImplicitUsageProviderTest extends SymfonyLightCodeInsightFix
         assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onFooBar")));
     }
 
+    public void testEventSubscriberGetAsEventListenerCombinedTest() {
+        PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
+                "namespace App\\EventListener;\n" +
+                "\n" +
+                "use Symfony\\Component\\EventDispatcher\\Attribute\\AsEventListener;\n" +
+                "\n" +
+                "#[AsEventListener(method: 'onMethodAttr')]\n" +
+                "#[AsEventListener(event: 'event-name')]\n" +
+                "#[AsEventListener]\n" +
+                "final class MyMultiListener\n" +
+                "{\n" +
+                "    public function onMethodAttr(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "    public function onEventName(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "    public function __invoke(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "    #[AsEventListener]\n" +
+                "    public function onMethod(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "    public function onUnregistered(): void\n" +
+                "    {\n" +
+                "    }\n" +
+                "\n" +
+                "}"
+        );
+
+        PhpClass phpClass = PhpElementsUtil.getFirstClassFromFile((PhpFile) psiFile.getContainingFile());
+
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onMethodAttr")));
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onEventName")));
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("__invoke")));
+        assertTrue(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onMethod")));
+        assertFalse(new SymfonyImplicitUsageProvider().isImplicitUsage(phpClass.findOwnMethodByName("onUnregistered")));
+    }
+
     public void testTwigExtensionRegisteredAsServiceWithFunctionMethodImplementedIsMarkedUsed() {
         PsiFile psiFile = myFixture.configureByText(PhpFileType.INSTANCE, "<?php\n" +
             "\n" +


### PR DESCRIPTION
Currently `#[AsEventListener]` only marks methods as implicitly used when the attribute is placed on the class and has an explicit `method` argument. But in my experience that's not the most common usage of the attribute and both the [documentation](https://symfony.com/doc/current/event_dispatcher.html#defining-event-listeners-with-php-attributes) and unit tests ([1](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedMultiListener.php), [2](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedInvokableListener.php)) show multiple possibilities, which are:
1. `#[AsEventListener]` on the method itself (I believe the most common)
2. `#[AsEventListener]` on the class with an explicit `method` specified
3. `#[AsEventListener]` on a class which has an `__invoke()` method
4. `#[AsEventListener]` on a class with an event specified but no method, in which case the method name is automatically determined based on the event name (`on<event name>`)

Currently only 2 is supported. This adds support for 1, 3 and 4 as well. The logic for this (including the regular expressions) is reused from Symfonys code here: https://github.com/symfony/symfony/blob/82acd7a7d6fe7a12200e949b6268ce5ba13e5e74/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php#L71-L96