### PR TITLE
add workaround to remove duplicate element for querybuilder after dot…

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/querybuilder/util/MatcherUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/doctrine/querybuilder/util/MatcherUtil.java
@@ -11,13 +11,13 @@ import org.jetbrains.annotations.Nullable;
  */
 public class MatcherUtil {
 
-    private static MethodMatcher.CallToSignature[] SELECT_FIELDS = new MethodMatcher.CallToSignature[] {
+    private static final MethodMatcher.CallToSignature[] SELECT_FIELDS = new MethodMatcher.CallToSignature[] {
         new MethodMatcher.CallToSignature("\\Doctrine\\ORM\\QueryBuilder", "orderBy"),
         new MethodMatcher.CallToSignature("\\Doctrine\\ORM\\QueryBuilder", "addOrderBy"),
         new MethodMatcher.CallToSignature("\\Doctrine\\ORM\\QueryBuilder", "set"),
     };
 
-    private static MethodMatcher.CallToSignature[] SELECT_FIELDS_VARIADIC = new MethodMatcher.CallToSignature[] {
+    private static final MethodMatcher.CallToSignature[] SELECT_FIELDS_VARIADIC = new MethodMatcher.CallToSignature[] {
         new MethodMatcher.CallToSignature("\\Doctrine\\ORM\\QueryBuilder", "select"),
         new MethodMatcher.CallToSignature("\\Doctrine\\ORM\\QueryBuilder", "addSelect"),
         new MethodMatcher.CallToSignature("\\Doctrine\\ORM\\QueryBuilder", "groupBy"),


### PR DESCRIPTION
…, for parameters which provide injected languages on some parameters from PhpStorm itself