### PR TITLE
fix: help buttons targeting a not found page

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/SettingsForm.form
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/SettingsForm.form
@@ -270,7 +270,7 @@
         <properties>
           <horizontalAlignment value="0"/>
           <horizontalTextPosition value="4"/>
-          <text value="Open Help Page"/>
+          <text value="Project Page / Documentation"/>
         </properties>
       </component>
       <component id="47a96" class="javax.swing.JButton" binding="buttonReindex">

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/SettingsForm.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/SettingsForm.java
@@ -68,7 +68,7 @@ public class SettingsForm implements Configurable {
             @Override
             public void mouseClicked(MouseEvent e) {
                 super.mouseClicked(e);
-                IdeHelper.openUrl(Symfony2ProjectComponent.HELP_URL);
+                IdeHelper.openUrl("https://espend.de/phpstorm/plugin/symfony");
             }
         });
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/Symfony2ProjectComponent.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/Symfony2ProjectComponent.java
@@ -54,7 +54,6 @@ public class Symfony2ProjectComponent {
         }
     }
 
-    public static final String HELP_URL = "https://espend.de/phpstorm/plugin/symfony";
     final private static Logger LOG = Logger.getInstance("Symfony-Plugin");
     private static final ExtensionPointName<ServiceContainerLoader> SERVICE_CONTAINER_POINT_NAME = new ExtensionPointName<>("fr.adrienbrault.idea.symfony2plugin.extension.ServiceContainerLoader");
     public static final ExtensionPointName<PluginConfigurationExtension> PLUGIN_CONFIGURATION_EXTENSION = new ExtensionPointName<>("fr.adrienbrault.idea.symfony2plugin.extension.PluginConfigurationExtension");

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/ui/MethodParameterReferenceSettingsForm.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/ui/MethodParameterReferenceSettingsForm.java
@@ -57,7 +57,7 @@ public class MethodParameterReferenceSettingsForm  implements Configurable {
             @Override
             public void mouseClicked(MouseEvent e) {
                 super.mouseClicked(e);
-                IdeHelper.openUrl(Symfony2ProjectComponent.HELP_URL + "extension/method_parameter.html");
+                IdeHelper.openUrl("https://www.jetbrains.com/help/phpstorm/symfony-creating-helper-functions.html#method-parameter");
             }
         });
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/ui/MethodSignatureTypeSettingsForm.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/ui/MethodSignatureTypeSettingsForm.java
@@ -55,7 +55,7 @@ public class MethodSignatureTypeSettingsForm  implements Configurable {
             @Override
             public void mouseClicked(MouseEvent e) {
                 super.mouseClicked(e);
-                IdeHelper.openUrl(Symfony2ProjectComponent.HELP_URL + "extension/signature_type.html");
+                IdeHelper.openUrl("https://www.jetbrains.com/help/phpstorm/symfony-creating-helper-functions.html#signature-types");
             }
         });
 


### PR DESCRIPTION
The `help` button in `Settings > PHP > Symfony > Method References` is targeting `https://espend.de/phpstorm/plugin/symfonyextension/method_parameter.html`

The `help` button in `Settings > PHP > Symfony > Type Provider` is targeting `https://espend.de/phpstorm/plugin/symfonyextension/signature_type.html`

And both url are 404 Not found.

In this MR we replace url by those targeting PHPStorm documentation (the new documentation) https://www.jetbrains.com/help/phpstorm/symfony-support.html

As `HELP_URL` is only used on settings main page I remove the constant to replace it by a string. (Tell me if it's good for you)

I also change the `buttonHelp` label by `Project Page / Documentation` as it's not the Help page anymore. But the project Page and this project page contains documentation like. (I use the same wording we can found on plugin page here https://plugins.jetbrains.com/plugin/7219-symfony-support to be consistent)