### PR TITLE
Add support for `#[AutowireServiceClosure]`, `#[AutowireMethodOf]`, and `#[AutowireCallable]` attributes with completion and navigation

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
@@ -79,6 +79,9 @@ public class ServiceContainerUtil {
     public static final String DECORATOR_ATTRIBUTE_CLASS = "\\Symfony\\Component\\DependencyInjection\\Attribute\\AsDecorator";
     public static final String AUTOCONFIGURE_ATTRIBUTE_CLASS = "\\Symfony\\Component\\DependencyInjection\\Attribute\\Autoconfigure";
     public static final String AUTOWIRE_LOCATOR_ATTRIBUTE_CLASS = "\\Symfony\\Component\\DependencyInjection\\Attribute\\AutowireLocator";
+    public static final String AUTOWIRE_SERVICE_CLOSURE_ATTRIBUTE_CLASS = "\\Symfony\\Component\\DependencyInjection\\Attribute\\AutowireServiceClosure";
+    public static final String AUTOWIRE_CALLABLE_ATTRIBUTE_CLASS = "\\Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable";
+    public static final String AUTOWIRE_METHOD_OF_ATTRIBUTE_CLASS = "\\Symfony\\Component\\DependencyInjection\\Attribute\\AutowireMethodOf";
 
     @NotNull
     public static Collection<ServiceSerializable> getServicesInFile(@NotNull PsiFile psiFile) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/registrar/DicGotoCompletionRegistrar.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/registrar/DicGotoCompletionRegistrar.java
@@ -5,27 +5,30 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
-import com.jetbrains.php.lang.psi.elements.PhpAttribute;
-import com.jetbrains.php.lang.psi.elements.PhpClass;
-import com.jetbrains.php.lang.psi.elements.StringLiteralExpression;
+import com.jetbrains.php.lang.psi.elements.*;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2Icons;
 import fr.adrienbrault.idea.symfony2plugin.codeInsight.GotoCompletionProvider;
 import fr.adrienbrault.idea.symfony2plugin.codeInsight.GotoCompletionRegistrar;
 import fr.adrienbrault.idea.symfony2plugin.codeInsight.GotoCompletionRegistrarParameter;
 import fr.adrienbrault.idea.symfony2plugin.codeInsight.utils.GotoCompletionUtil;
 import fr.adrienbrault.idea.symfony2plugin.config.component.ParameterLookupElement;
+import fr.adrienbrault.idea.symfony2plugin.config.yaml.ParameterPercentWrapInsertHandler;
 import fr.adrienbrault.idea.symfony2plugin.dic.ContainerParameter;
 import fr.adrienbrault.idea.symfony2plugin.dic.ServiceCompletionProvider;
+import fr.adrienbrault.idea.symfony2plugin.dic.container.util.DotEnvUtil;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.util.ServiceContainerUtil;
 import fr.adrienbrault.idea.symfony2plugin.stubs.ContainerCollectionResolver;
 import fr.adrienbrault.idea.symfony2plugin.util.MethodMatcher;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
 import fr.adrienbrault.idea.symfony2plugin.util.completion.TagNameCompletionProvider;
 import fr.adrienbrault.idea.symfony2plugin.util.dict.ServiceUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -72,8 +75,8 @@ public class DicGotoCompletionRegistrar implements GotoCompletionRegistrar {
             }
         );
 
-        // #[Autowire('<caret>')]
-        // #[Autowire(value: '<caret>')]
+        // #[Autowire('%kernel.project_dir%')]
+        // #[Autowire(value: '%kernel.project_dir%')]
         registrar.register(
             PlatformPatterns.or(
                 PhpElementsUtil.getFirstAttributeStringPattern(ServiceContainerUtil.AUTOWIRE_ATTRIBUTE_CLASS),
@@ -86,7 +89,7 @@ public class DicGotoCompletionRegistrar implements GotoCompletionRegistrar {
 
                 PhpAttribute phpAttribute = PsiTreeUtil.getParentOfType(context, PhpAttribute.class);
                 if (phpAttribute != null) {
-                    return new ParameterContributor((StringLiteralExpression) context);
+                    return new ParameterWithPercentWrapContributor((StringLiteralExpression) context);
                 }
 
                 return null;
@@ -124,8 +127,49 @@ public class DicGotoCompletionRegistrar implements GotoCompletionRegistrar {
             }
         );
 
+        // #[Autowire(param: 'kernel.debug')]
+        registrar.register(
+            PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_ATTRIBUTE_CLASS, "param"),
+            psiElement -> {
+                PsiElement context = psiElement.getContext();
+                if (!(context instanceof StringLiteralExpression)) {
+                    return null;
+                }
+
+                PhpAttribute phpAttribute = PsiTreeUtil.getParentOfType(context, PhpAttribute.class);
+                if (phpAttribute != null) {
+                    return new ParameterContributor((StringLiteralExpression) context);
+                }
+
+                return null;
+            }
+        );
+
+        // #[Autowire(env: 'SOME_ENV_VAR')]
+        registrar.register(
+            PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_ATTRIBUTE_CLASS, "env"),
+            psiElement -> {
+                PsiElement context = psiElement.getContext();
+                if (!(context instanceof StringLiteralExpression)) {
+                    return null;
+                }
+
+                PhpAttribute phpAttribute = PsiTreeUtil.getParentOfType(context, PhpAttribute.class);
+                if (phpAttribute != null) {
+                    return new EnvironmentVariableContributor((StringLiteralExpression) context);
+                }
+
+                return null;
+            }
+        );
+
         // #[Autowire(service: 'some_service')]
         // #[AsDecorator(decorates: 'some_service')]
+        // #[AutowireServiceClosure('some_service')]
+        // #[AutowireServiceClosure(service: 'some_service')]
+        // #[AutowireMethodOf('some_service')]
+        // #[AutowireMethodOf(service: 'some_service')]
+        // #[AutowireCallable(service: 'some_service')]
         registrar.register(
             PlatformPatterns.or(
                 PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_ATTRIBUTE_CLASS, "service"),
@@ -145,7 +189,20 @@ public class DicGotoCompletionRegistrar implements GotoCompletionRegistrar {
                 // #[AutowireLocator(exclude: ['app.some_tag'])]
                 // #[AutowireLocator(exclude: 'app.some_tag')]
                 PhpElementsUtil.getAttributeNamedArgumentArrayStringPattern(ServiceContainerUtil.AUTOWIRE_LOCATOR_ATTRIBUTE_CLASS, "exclude"),
-                PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_LOCATOR_ATTRIBUTE_CLASS, "exclude")
+                PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_LOCATOR_ATTRIBUTE_CLASS, "exclude"),
+
+                // #[AutowireServiceClosure('some_service')]
+                // #[AutowireServiceClosure(service: 'some_service')]
+                PhpElementsUtil.getFirstAttributeStringPattern(ServiceContainerUtil.AUTOWIRE_SERVICE_CLOSURE_ATTRIBUTE_CLASS),
+                PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_SERVICE_CLOSURE_ATTRIBUTE_CLASS, "service"),
+
+                // #[AutowireMethodOf('some_service')]
+                // #[AutowireMethodOf(service: 'some_service')]
+                PhpElementsUtil.getFirstAttributeStringPattern(ServiceContainerUtil.AUTOWIRE_METHOD_OF_ATTRIBUTE_CLASS),
+                PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_METHOD_OF_ATTRIBUTE_CLASS, "service"),
+
+                // #[AutowireCallable(service: 'some_service')]
+                PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_CALLABLE_ATTRIBUTE_CLASS, "service")
             ),
             psiElement -> {
                 PsiElement context = psiElement.getContext();
@@ -156,6 +213,24 @@ public class DicGotoCompletionRegistrar implements GotoCompletionRegistrar {
                 PhpAttribute phpAttribute = PsiTreeUtil.getParentOfType(context, PhpAttribute.class);
                 if (phpAttribute != null) {
                     return new ServiceContributor((StringLiteralExpression) context);
+                }
+
+                return null;
+            }
+        );
+
+        // #[AutowireCallable(service: 'some_service', method: 'methodName')]
+        registrar.register(
+            PhpElementsUtil.getAttributeNamedArgumentStringPattern(ServiceContainerUtil.AUTOWIRE_CALLABLE_ATTRIBUTE_CLASS, "method"),
+            psiElement -> {
+                PsiElement context = psiElement.getContext();
+                if (!(context instanceof StringLiteralExpression)) {
+                    return null;
+                }
+
+                PhpAttribute phpAttribute = PsiTreeUtil.getParentOfType(context, PhpAttribute.class);
+                if (phpAttribute != null) {
+                    return new AutowireCallableMethodContributor((StringLiteralExpression) context, phpAttribute);
                 }
 
                 return null;
@@ -253,6 +328,134 @@ public class DicGotoCompletionRegistrar implements GotoCompletionRegistrar {
             }
 
             return List.of(phpClass);
+        }
+    }
+
+    private static class EnvironmentVariableContributor extends GotoCompletionProvider {
+        public EnvironmentVariableContributor(@NotNull StringLiteralExpression element) {
+            super(element);
+        }
+
+        @Override
+        public @NotNull Collection<LookupElement> getLookupElements() {
+            Collection<LookupElement> results = new ArrayList<>();
+
+            for (String envVar : DotEnvUtil.getEnvironmentVariables(getProject())) {
+                results.add(LookupElementBuilder.create(envVar).withIcon(Symfony2Icons.SYMFONY));
+            }
+
+            return results;
+        }
+
+        @Override
+        public @NotNull Collection<PsiElement> getPsiTargets(PsiElement element) {
+            String contents = GotoCompletionUtil.getStringLiteralValue(element);
+            if (contents == null) {
+                return Collections.emptyList();
+            }
+
+            // Strip processor prefix if present: bool:SOME_ENV_VAR -> SOME_ENV_VAR
+            // Supports: int:, bool:, string:, json:, resolve:, etc.
+            Matcher matcher = Pattern.compile("^[\\w-_^:]+:(.*)$", Pattern.MULTILINE).matcher(contents);
+            if (matcher.find()) {
+                contents = matcher.group(1);
+            }
+
+            return DotEnvUtil.getEnvironmentVariableTargets(getProject(), contents);
+        }
+    }
+
+    private static class ParameterWithPercentWrapContributor extends GotoCompletionProvider {
+        public ParameterWithPercentWrapContributor(@NotNull StringLiteralExpression element) {
+            super(element);
+        }
+
+        @Override
+        public @NotNull Collection<LookupElement> getLookupElements() {
+            Collection<LookupElement> results = new ArrayList<>();
+
+            for (Map.Entry<String, ContainerParameter> entry : ContainerCollectionResolver.getParameters(getProject()).entrySet()) {
+                results.add(new ParameterLookupElement(
+                    entry.getValue(),
+                    ParameterPercentWrapInsertHandler.getInstance(),
+                    getElement().getText()
+                ));
+            }
+
+            return results;
+        }
+
+        @Override
+        public @NotNull Collection<PsiElement> getPsiTargets(PsiElement element) {
+            String contents = GotoCompletionUtil.getStringLiteralValue(element);
+            if (contents == null) {
+                return Collections.emptyList();
+            }
+
+            // Strip % characters if present: %kernel.debug% -> kernel.debug
+            contents = StringUtils.strip(contents, "%");
+
+            return ServiceUtil.getParameterDefinition(getProject(), contents);
+        }
+    }
+
+    private static class AutowireCallableMethodContributor extends GotoCompletionProvider {
+        private final PhpAttribute phpAttribute;
+
+        public AutowireCallableMethodContributor(@NotNull StringLiteralExpression element, @NotNull PhpAttribute phpAttribute) {
+            super(element);
+            this.phpAttribute = phpAttribute;
+        }
+
+        @Override
+        public @NotNull Collection<LookupElement> getLookupElements() {
+            Collection<LookupElement> results = new ArrayList<>();
+
+            PhpClass phpClass = getServiceClass();
+            if (phpClass == null) {
+                return results;
+            }
+
+            for (Method method : phpClass.getMethods()) {
+                // Only public non-static methods
+                if (method.getAccess().isPublic() && !method.isStatic()) {
+                    results.add(LookupElementBuilder.create(method.getName())
+                        .withIcon(method.getIcon())
+                        .withTypeText(phpClass.getName(), true));
+                }
+            }
+
+            return results;
+        }
+
+        @Override
+        public @NotNull Collection<PsiElement> getPsiTargets(PsiElement element) {
+            String methodName = GotoCompletionUtil.getStringLiteralValue(element);
+            if (methodName == null) {
+                return Collections.emptyList();
+            }
+
+            PhpClass phpClass = getServiceClass();
+            if (phpClass == null) {
+                return Collections.emptyList();
+            }
+
+            Method method = phpClass.findMethodByName(methodName);
+            if (method != null && method.getAccess().isPublic() && !method.isStatic()) {
+                return List.of(method);
+            }
+
+            return Collections.emptyList();
+        }
+
+        private PhpClass getServiceClass() {
+            // Find the 'service' argument in the same attribute using the utility method
+            String serviceId = PhpElementsUtil.getAttributeArgumentStringByName(phpAttribute, "service");
+            if (serviceId != null && !serviceId.isEmpty()) {
+                return ServiceUtil.getResolvedClassDefinition(getProject(), serviceId);
+            }
+
+            return null;
         }
     }
 }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/registrar/DicGotoCompletionRegistrarTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/registrar/DicGotoCompletionRegistrarTest.java
@@ -13,6 +13,7 @@ public class DicGotoCompletionRegistrarTest extends SymfonyLightCodeInsightFixtu
         super.setUp();
         myFixture.configureFromExistingVirtualFile(myFixture.copyFileToProject("classes.php"));
         myFixture.copyFileToProject("services.yml");
+        myFixture.copyFileToProject(".env");
     }
 
     public String getTestDataPath() {
@@ -95,7 +96,7 @@ public class DicGotoCompletionRegistrarTest extends SymfonyLightCodeInsightFixtu
                 "class MyService\n" +
                 "{\n" +
                 "    public function __construct(\n" +
-                "        #[Autowire('fo<caret>o')]\n" +
+                "        #[Autowire('%fo<caret>o%')]\n" +
                 "        private $parameter2" +
                 "    ) {}\n" +
                 "}",
@@ -123,7 +124,7 @@ public class DicGotoCompletionRegistrarTest extends SymfonyLightCodeInsightFixtu
                 "class MyService\n" +
                 "{\n" +
                 "    public function __construct(\n" +
-                "        #[Autowire(value: 'fo<caret>o')]\n" +
+                "        #[Autowire(value: '%fo<caret>o%')]\n" +
                 "        private $parameter2" +
                 "    ) {}\n" +
                 "}",
@@ -295,6 +296,298 @@ public class DicGotoCompletionRegistrarTest extends SymfonyLightCodeInsightFixtu
                 "#[When('<caret>')]\n" +
                 "class HandlerCollection {}",
             "dev", "test", "prod"
+        );
+    }
+
+    public void testParameterContributorForParamAttribute() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\Autowire;\n" +
+                "\n" +
+                "class MyService\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[Autowire(param: '<caret>')]\n" +
+                "        private bool $debugMode" +
+                "    ) {}\n" +
+                "}",
+            "foo"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\Autowire;\n" +
+                "\n" +
+                "class MyService\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[Autowire(param: 'fo<caret>o')]\n" +
+                "        private bool $debugMode" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+    }
+
+    public void testEnvironmentVariableContributorForEnvAttribute() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\Autowire;\n" +
+                "\n" +
+                "class MyService\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[Autowire(env: '<caret>')]\n" +
+                "        private string $senderName" +
+                "    ) {}\n" +
+                "}",
+            "DATABASE_URL", "APP_ENV", "SOME_ENV_VAR"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\Autowire;\n" +
+                "\n" +
+                "class MyService\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[Autowire(env: 'DATABASE<caret>_URL')]\n" +
+                "        private string $senderName" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+    }
+
+    public void testEnvironmentVariableContributorForEnvAttributeWithProcessor() {
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\Autowire;\n" +
+                "\n" +
+                "class MyService\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[Autowire(env: 'bool:SOME_ENV<caret>_VAR')]\n" +
+                "        private bool $allowAttachments" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\Autowire;\n" +
+                "\n" +
+                "class MyService\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[Autowire(env: 'int:APP<caret>_ENV')]\n" +
+                "        private int $someValue" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\Autowire;\n" +
+                "\n" +
+                "class MyService\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[Autowire(env: 'resolve:DATABASE<caret>_URL')]\n" +
+                "        private string $dbUrl" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+    }
+
+    public void testServiceContributorForAutowireServiceClosure() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireServiceClosure;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireServiceClosure('<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "foo_bar_service"
+        );
+
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireServiceClosure;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireServiceClosure(service: '<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "foo_bar_service"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireServiceClosure;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireServiceClosure('foo_bar<caret>_service')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+    }
+
+    public void testServiceContributorForAutowireMethodOf() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireMethodOf;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireMethodOf('<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "foo_bar_service"
+        );
+
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireMethodOf;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireMethodOf(service: '<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "foo_bar_service"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireMethodOf;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireMethodOf('foo_bar<caret>_service')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+    }
+
+    public void testServiceContributorForAutowireCallable() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: '<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "foo_bar_service"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: 'foo_bar<caret>_service')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+    }
+
+    public void testMethodContributorForAutowireCallable() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: 'foo_bar_service', method: '<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "format", "process"
+        );
+
+        assertCompletionNotContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: 'foo_bar_service', method: '<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "privateMethod", "staticMethod"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: 'foo_bar_service', method: 'for<caret>mat')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
+        );
+    }
+
+    public void testMethodContributorForAutowireCallableWithClassConstant() {
+        assertCompletionContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "use Foo\\Bar;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: Bar::class, method: '<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "format", "process"
+        );
+
+        assertCompletionNotContains(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "use Foo\\Bar;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: Bar::class, method: '<caret>')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            "privateMethod", "staticMethod"
+        );
+
+        assertNavigationMatch(PhpFileType.INSTANCE, "<?php\n" +
+                "use Symfony\\Component\\DependencyInjection\\Attribute\\AutowireCallable;\n" +
+                "use Foo\\Bar;\n" +
+                "\n" +
+                "class HandlerCollection\n" +
+                "{\n" +
+                "    public function __construct(\n" +
+                "        #[AutowireCallable(service: Bar::class, method: 'for<caret>mat')]\n" +
+                "        private $formatter" +
+                "    ) {}\n" +
+                "}",
+            PlatformPatterns.psiElement()
         );
     }
 }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/registrar/fixtures/.env
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/registrar/fixtures/.env
@@ -1,0 +1,4 @@
+DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
+APP_ENV=dev
+APP_SECRET=secret123
+SOME_ENV_VAR=test_value

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/registrar/fixtures/classes.php
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/dic/registrar/fixtures/classes.php
@@ -17,11 +17,15 @@ namespace Symfony\Component\DependencyInjection\Attribute
          * @param string|null $value      Parameter value (ie "%kernel.project_dir%/some/path")
          * @param string|null $service    Service ID (ie "some.service")
          * @param string|null $expression Expression (ie 'service("some.service").someMethod()')
+         * @param string|null $param      Container parameter name (ie "kernel.debug")
+         * @param string|null $env        Environment variable name (ie "DATABASE_URL")
          */
         public function __construct(
             string $value = null,
             string $service = null,
             string $expression = null,
+            string $param = null,
+            string $env = null,
         ) {}
     }
 
@@ -73,6 +77,31 @@ namespace Symfony\Component\DependencyInjection\Attribute
         ) {
         }
     }
+
+    class AutowireServiceClosure
+    {
+        public function __construct(
+            public ?string $service = null,
+        ) {
+        }
+    }
+
+    class AutowireCallable
+    {
+        public function __construct(
+            public ?string $service = null,
+            public ?string $method = null,
+        ) {
+        }
+    }
+
+    class AutowireMethodOf
+    {
+        public function __construct(
+            public ?string $service = null,
+        ) {
+        }
+    }
 }
 
 namespace
@@ -99,6 +128,21 @@ namespace Foo
 {
     class Bar
     {
+        public function format($message) {
+            return strtoupper($message);
+        }
+
+        public function process($data) {
+            return $data;
+        }
+
+        private function privateMethod() {
+            return 'private';
+        }
+
+        public static function staticMethod() {
+            return 'static';
+        }
     }
 }
 


### PR DESCRIPTION
fix:
- Strip processor prefixes (e.g., `bool:`, `int:`) from `#[Autowire(env:)]` attributes for navigation and completion
- Add `%parameter%` wrapping support in `#[Autowire()]` attributes with completion and navigation
- Add support for `#[Autowire(param:)]` and `#[Autowire(env:)]` attributes with completion and navigation