### PR TITLE
Add coloration for `@prop` and `@block` Twig comments from Symfony UX

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
@@ -1,0 +1,231 @@
+package fr.adrienbrault.idea.symfony2plugin.templating.annotation;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.CachedValueProvider;
+import com.intellij.psi.util.CachedValuesManager;
+import com.jetbrains.php.lang.highlighter.PhpHighlightingData;
+import com.jetbrains.twig.TwigFile;
+import com.jetbrains.twig.TwigTokenTypes;
+import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
+import fr.adrienbrault.idea.symfony2plugin.util.UxUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Provides syntax highlighting for Symfony UX Toolkit Twig comment annotations.
+ *
+ * Supports:
+ * - {# @prop name type Description #}
+ * - {# @block name Description #}
+ *
+ * Uses PHP's PHPDoc highlighting colors for consistency with `@property` annotations.
+ *
+ * @see <a href="https://github.com/symfony/ux-toolkit">Symfony UX Toolkit</a>
+ */
+public class TwigUxToolkitAnnotator implements Annotator {
+    /**
+     * Pattern for @prop annotations.
+     * Format: @prop name type Description
+     * Example: @prop open boolean Whether the item is open by default.
+     *
+     * Supports complex types:
+     * - Simple: string, boolean, int
+     * - Nullable: ?string, string|null
+     * - Union: string|int|null
+     * - Generic: array<string>, Collection<int, Item>
+     * - Literal strings: 'vertical'|'horizontal'
+     * - FQCN: App\Entity\Item, \DateTime
+     * - Arrays: string[], Item[]
+     *
+     * @see <a href="https://regex101.com/r/3JXNX7/1">Regex101</a>
+     */
+    private static final Pattern PROP_PATTERN = Pattern.compile(
+        "(@prop)\\s+(\\w+)\\s+(\\S+)\\s+(.+?)\\s*$",
+        Pattern.DOTALL
+    );
+
+    /**
+     * Pattern for @block annotations.
+     * Format: @block name Description
+     * Example: @block content The item content.
+     *
+     * @see <a href="https://regex101.com/r/jYjXpq/1">Regex101</a>
+     */
+    private static final Pattern BLOCK_PATTERN = Pattern.compile(
+        "(@block)\\s+(\\w+)\\s+(.+?)\\s*$",
+        Pattern.DOTALL
+    );
+
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (!Symfony2ProjectComponent.isEnabled(element.getProject())) {
+            return;
+        }
+
+        // Only process Twig comment text tokens
+        if (element.getNode().getElementType() != TwigTokenTypes.COMMENT_TEXT) {
+            return;
+        }
+
+        String text = element.getText();
+        int startOffset = element.getTextRange().getStartOffset();
+
+        // Try to match @prop pattern
+        Matcher propMatcher = PROP_PATTERN.matcher(text);
+        if (propMatcher.find()) {
+            annotateProp(holder, startOffset, propMatcher, getPropDefaults(element));
+            return;
+        }
+
+        // Try to match @block pattern
+        Matcher blockMatcher = BLOCK_PATTERN.matcher(text);
+        if (blockMatcher.find()) {
+            annotateBlock(holder, startOffset, blockMatcher);
+        }
+    }
+
+    /**
+     * Annotates a @prop comment with syntax highlighting.
+     * Highlights: @prop keyword, property name, and type.
+     *
+     * Uses PHP PHPDoc colors:
+     * - DOC_TAG for @prop keyword (like @property in PHPDoc)
+     * - DOC_PROPERTY_IDENTIFIER for property name (like $foo in @property string $foo)
+     * - DOC_IDENTIFIER for type (like string in @property string $foo)
+     *
+     * The property name also carries a hover tooltip with its type, default value (sourced from the
+     * {@code {% props %}} tag, the single source of truth for defaults) and description.
+     */
+    private void annotateProp(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher, @NotNull Map<String, String> propDefaults) {
+        // Highlight @prop keyword (group 1) - like @property
+        highlightRange(holder, startOffset, matcher, 1, PhpHighlightingData.DOC_TAG);
+
+        // Highlight property name (group 2) - like $foo in @property string $foo - with a hover tooltip
+        String name = matcher.group(2);
+        String defaultValue = name != null ? propDefaults.get(name) : null;
+        String tooltip = buildPropTooltip(name, matcher.group(3), matcher.group(4), defaultValue);
+        highlightRangeWithTooltip(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER, tooltip);
+
+        // Highlight type (group 3) - like string in @property string $foo
+        highlightRange(holder, startOffset, matcher, 3, PhpHighlightingData.DOC_IDENTIFIER);
+    }
+
+    /**
+     * Reads the prop default values declared in the template's {@code {% props %}} tag, cached per file.
+     */
+    private static @NotNull Map<String, String> getPropDefaults(@NotNull PsiElement element) {
+        PsiFile file = element.getContainingFile();
+        if (!(file instanceof TwigFile twigFile)) {
+            return Collections.emptyMap();
+        }
+
+        return CachedValuesManager.getCachedValue(twigFile, () ->
+            CachedValueProvider.Result.create(UxUtil.getComponentTemplatePropDefaults(twigFile), twigFile)
+        );
+    }
+
+    /**
+     * Builds the hover tooltip for a prop: {@code name : type = default} followed by its description.
+     */
+    private static @NotNull String buildPropTooltip(@Nullable String name, @Nullable String type, @Nullable String description, @Nullable String defaultValue) {
+        StringBuilder tooltip = new StringBuilder();
+
+        if (name != null) {
+            tooltip.append("<code>").append(StringUtil.escapeXmlEntities(name)).append("</code>");
+        }
+
+        if (type != null) {
+            tooltip.append(" : <code>").append(StringUtil.escapeXmlEntities(type)).append("</code>");
+        }
+
+        if (defaultValue != null) {
+            tooltip.append(" = <code>").append(StringUtil.escapeXmlEntities(defaultValue)).append("</code>");
+        }
+
+        if (description != null && !description.isBlank()) {
+            tooltip.append("<br/>").append(StringUtil.escapeXmlEntities(description.trim().replaceAll("\\s+", " ")));
+        }
+
+        return tooltip.toString();
+    }
+
+    /**
+     * Like {@link #highlightRange} but attaches a hover tooltip (which {@code newSilentAnnotation} cannot carry).
+     */
+    private void highlightRangeWithTooltip(
+        @NotNull AnnotationHolder holder,
+        int baseOffset,
+        @NotNull Matcher matcher,
+        int group,
+        @NotNull TextAttributesKey textAttributesKey,
+        @NotNull String tooltip
+    ) {
+        if (matcher.group(group) == null) {
+            return;
+        }
+
+        TextRange range = new TextRange(
+            baseOffset + matcher.start(group),
+            baseOffset + matcher.end(group)
+        );
+
+        holder.newAnnotation(HighlightSeverity.INFORMATION, StringUtil.removeHtmlTags(tooltip))
+            .range(range)
+            .tooltip(tooltip)
+            .textAttributes(textAttributesKey)
+            .create();
+    }
+
+    /**
+     * Annotates a @block comment with syntax highlighting.
+     * Highlights: @block keyword and block name.
+     *
+     * Uses PHP PHPDoc colors:
+     * - DOC_TAG for @block keyword
+     * - DOC_PROPERTY_IDENTIFIER for block name
+     */
+    private void annotateBlock(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher) {
+        // Highlight @block keyword (group 1)
+        highlightRange(holder, startOffset, matcher, 1, PhpHighlightingData.DOC_TAG);
+
+        // Highlight block name (group 2)
+        highlightRange(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER);
+    }
+
+    /**
+     * Creates a silent annotation with the specified text attributes for a regex group match.
+     */
+    private void highlightRange(
+        @NotNull AnnotationHolder holder,
+        int baseOffset,
+        @NotNull Matcher matcher,
+        int group,
+        @NotNull TextAttributesKey textAttributesKey
+    ) {
+        if (matcher.group(group) == null) {
+            return;
+        }
+
+        TextRange range = new TextRange(
+            baseOffset + matcher.start(group),
+            baseOffset + matcher.end(group)
+        );
+
+        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .range(range)
+            .textAttributes(textAttributesKey)
+            .create();
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.formatter.FormatterUtil;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.CachedValue;
 import com.intellij.psi.util.CachedValueProvider;
 import com.intellij.psi.util.CachedValuesManager;
@@ -828,6 +829,99 @@ public class UxUtil {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Extracts the prop default values from a component template's {@code {%- props -%}} tag.
+     *
+     * <p>Default values live only in the {@code {%- props -%}} declaration (the single source of
+     * truth), the same way Symfony UX Toolkit's {@code ComponentDocParser} sources them rather than
+     * from the {@code {# @prop #}} docblock. Each default is returned as written in the source
+     * (e.g. {@code false}, {@code 'brand'}, {@code ['a', 'b']}); commas inside arrays, hashes and
+     * strings are handled because the Twig parser nests them, so only the tag's top-level commas
+     * separate props. Props declared without a default (required props) are not included.
+     *
+     * @return prop name to its default expression, in declaration order
+     */
+    @NotNull
+    public static Map<String, String> getComponentTemplatePropDefaults(@NotNull TwigFile twigFile) {
+        Map<String, String> defaults = new LinkedHashMap<>();
+
+        for (PsiElement element : twigFile.getChildren()) {
+            if (!(element instanceof TwigCompositeElement) || element.getNode().getElementType() != TwigElementTypes.TAG) {
+                continue;
+            }
+
+            ASTNode[] children = element.getNode().getChildren(null);
+
+            int nameIndex = -1;
+            for (int i = 0; i < children.length; i++) {
+                if (children[i].getElementType() == TwigTokenTypes.TAG_NAME) {
+                    nameIndex = i;
+                    break;
+                }
+            }
+
+            if (nameIndex == -1 || !"props".equals(children[nameIndex].getText().trim())) {
+                continue;
+            }
+
+            List<ASTNode> segment = new ArrayList<>();
+            for (int i = nameIndex + 1; i < children.length; i++) {
+                IElementType type = children[i].getElementType();
+                if (type == TwigTokenTypes.STATEMENT_BLOCK_END) {
+                    break;
+                }
+
+                if (type == TwigTokenTypes.COMMA) {
+                    collectPropDefault(segment, defaults);
+                    segment.clear();
+                } else {
+                    segment.add(children[i]);
+                }
+            }
+            collectPropDefault(segment, defaults);
+
+            return defaults;
+        }
+
+        return defaults;
+    }
+
+    private static void collectPropDefault(@NotNull List<ASTNode> segment, @NotNull Map<String, String> defaults) {
+        String name = null;
+        int equalIndex = -1;
+
+        for (int i = 0; i < segment.size(); i++) {
+            ASTNode node = segment.get(i);
+            if (node.getText().isBlank()) {
+                continue;
+            }
+
+            if (name == null) {
+                if (node.getElementType() != TwigTokenTypes.IDENTIFIER) {
+                    return;
+                }
+                name = node.getText();
+            } else if (node.getElementType() == TwigTokenTypes.EQ) {
+                equalIndex = i;
+                break;
+            }
+        }
+
+        if (name == null || equalIndex == -1) {
+            return;
+        }
+
+        StringBuilder defaultValue = new StringBuilder();
+        for (int i = equalIndex + 1; i < segment.size(); i++) {
+            defaultValue.append(segment.get(i).getText());
+        }
+
+        String trimmed = defaultValue.toString().trim();
+        if (!trimmed.isEmpty()) {
+            defaults.put(name, trimmed);
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -234,6 +234,8 @@
         <lang.foldingBuilder language="PHP" implementationClass="fr.adrienbrault.idea.symfony2plugin.navigation.PhpFoldingBuilder"/>
         <lang.foldingBuilder language="Twig" implementationClass="fr.adrienbrault.idea.symfony2plugin.navigation.TwigFoldingBuilder"/>
 
+        <annotator language="Twig" implementationClass="fr.adrienbrault.idea.symfony2plugin.templating.annotation.TwigUxToolkitAnnotator"/>
+
         <completion.contributor language="any" implementationClass="fr.adrienbrault.idea.symfony2plugin.codeInsight.completion.CompletionContributor"/>
         <gotoDeclarationHandler implementation="fr.adrienbrault.idea.symfony2plugin.codeInsight.navigation.GotoHandler"/>
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
@@ -1,0 +1,235 @@
+package fr.adrienbrault.idea.symfony2plugin.tests.templating.annotation;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.jetbrains.php.lang.highlighter.PhpHighlightingData;
+import fr.adrienbrault.idea.symfony2plugin.templating.annotation.TwigUxToolkitAnnotator;
+import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+
+import java.util.List;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ * @see TwigUxToolkitAnnotator
+ */
+public class TwigUxToolkitAnnotatorTest extends SymfonyLightCodeInsightFixtureTestCase {
+
+    public void testPropAnnotationIsHighlighted() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // Verify that highlighting is applied (INFORMATION level annotations from our annotator)
+        assertTrue(
+            "Expected highlighting for @prop annotation",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    public void testPropAnnotationHighlightsPropertyName() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for property name",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testPropAnnotationHighlightsType() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for type",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testBlockAnnotationIsHighlighted() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @block content The item content. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for @block annotation",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    public void testBlockAnnotationHighlightsBlockName() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @block content The item content. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for block name",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testPropWithComplexType() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop items App\\Entity\\Item[] List of items #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for complex type",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testPropWithUnionType() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop value string|int|null The value #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for union type",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testRegularCommentNotHighlighted() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# This is a regular comment #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // Regular comments should not have our specific highlighting
+        assertFalse(
+            "Regular comments should not have DOC_COMMENT_TAG highlighting",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    public void testVarCommentNotAffected() {
+        // @var comments are handled by a different mechanism, ensure we don't interfere
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @var foo \\App\\Entity\\Foo #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // @var must not receive @prop/@block highlighting from TwigUxToolkitAnnotator.
+        // (@var is coloured by the separate TwigVarCommentAnnotator, which uses different keys;
+        // DOC_PROPERTY_IDENTIFIER is unique to a @prop name, so its absence proves we did not fire.)
+        assertFalse(
+            "@var comments should not be highlighted by TwigUxToolkitAnnotator",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testPropTooltipShowsDefaultFromPropsTag() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}\n" +
+            "{%- props open = false -%}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected a tooltip carrying the type, default value and description",
+            highlighting.stream().anyMatch(info ->
+                info.getToolTip() != null
+                    && info.getToolTip().contains("boolean")
+                    && info.getToolTip().contains("false")
+                    && info.getToolTip().contains("Whether the item is open by default.")
+            )
+        );
+    }
+
+    public void testPropTooltipOmitsDefaultForRequiredProp() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop id string Unique identifier. #}\n" +
+            "{%- props id -%}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // the tooltip still describes the prop...
+        assertTrue(
+            "Expected a tooltip carrying the type and description",
+            highlighting.stream().anyMatch(info ->
+                info.getToolTip() != null
+                    && info.getToolTip().contains("string")
+                    && info.getToolTip().contains("Unique identifier.")
+            )
+        );
+
+        // ...but shows no default assignment for a required prop
+        assertFalse(
+            "A required prop must not show a default value",
+            highlighting.stream().anyMatch(info ->
+                info.getToolTip() != null && info.getToolTip().contains("= <code>")
+            )
+        );
+    }
+
+    /**
+     * Helper method to check if a HighlightInfo has a specific TextAttributesKey.
+     */
+    private boolean hasTextAttributesKey(HighlightInfo info, TextAttributesKey expectedKey) {
+        if (info.forcedTextAttributesKey != null) {
+            return info.forcedTextAttributesKey.equals(expectedKey) ||
+                   info.forcedTextAttributesKey.getFallbackAttributeKey() != null &&
+                   info.forcedTextAttributesKey.getFallbackAttributeKey().equals(expectedKey);
+        }
+        return false;
+    }
+}

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
@@ -803,6 +803,39 @@ public class UxUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         assertEquals("Should only have 2 props", 2, props.size());
     }
 
+    public void testGetComponentTemplatePropDefaults() {
+        // defaults are read as written; required props (no "=") are excluded
+        assertEquals(
+            Map.of("open", "false", "variant", "'brand'", "as", "'div'"),
+            propDefaults("{%- props open = false, variant = 'brand', as = 'div' -%}")
+        );
+
+        Map<String, String> withRequired = propDefaults("{% props id, open = false %}");
+        assertEquals("false", withRequired.get("open"));
+        assertFalse("required prop without a default is excluded", withRequired.containsKey("id"));
+
+        // commas inside arrays and strings must not split props
+        Map<String, String> nested = propDefaults("{% props items = ['x', 'y'], label = 'a, b', open = false %}");
+        assertEquals("['x', 'y']", nested.get("items"));
+        assertEquals("'a, b'", nested.get("label"));
+        assertEquals("false", nested.get("open"));
+
+        // bare literals stay bare
+        assertEquals(Map.of("count", "0", "name", "null"), propDefaults("{% props count = 0, name = null %}"));
+
+        // non-literal default expression is kept verbatim
+        assertEquals("foo ~ bar", propDefaults("{% props label = foo ~ bar %}").get("label"));
+
+        // no props tag / other tags contribute nothing
+        assertTrue(propDefaults("<div>{{ foo }}</div>").isEmpty());
+        assertTrue(propDefaults("{% set foo = 'bar' %}").isEmpty());
+    }
+
+    private Map<String, String> propDefaults(@NotNull String source) {
+        TwigFile twigFile = (TwigFile) myFixture.configureByText(TwigFileType.INSTANCE, source);
+        return UxUtil.getComponentTemplatePropDefaults(twigFile);
+    }
+
     private void configureTwigNamespaceSettings(@NotNull TwigNamespaceSetting... settings) {
         Settings.getInstance(getProject()).twigNamespaces.clear();
         Settings.getInstance(getProject()).twigNamespaces.addAll(List.of(settings));


### PR DESCRIPTION
Close #2544

Mainly coded through Claude Opus 4.5, let me know what you think:
<img width="956" height="585" alt="image" src="https://github.com/user-attachments/assets/13e6c658-4973-4fac-ade2-927066899ab7" />

I re-used the colors from PHPDoc, but maybe it would be better if we re-use more "Twig" colors. 