### PR TITLE
Consider potential path mapping when parsing Twig namespace paths

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/util/ServiceContainerUtil.java
@@ -1026,13 +1026,9 @@ public class ServiceContainerUtil {
      * - ...
      */
     public static Collection<String> getContainerFiles(@NotNull Project project) {
-        return CachedValuesManager.getManager(project)
-            .getCachedValue(
-                project,
-                SYMFONY_COMPILED_SERVICE_WATCHER,
-                () -> CachedValueProvider.Result.create(getContainerFilesInner(project), PsiModificationTracker.MODIFICATION_COUNT),
-                false
-            );
+        // Directly use the inner cache with AbsoluteFileModificationTracker
+        // This ensures cache invalidation works properly when var/cache is deleted/recreated
+        return getContainerFilesInner(project);
     }
 
     /**
@@ -1110,9 +1106,37 @@ public class ServiceContainerUtil {
                 }
             }
 
-            Set<String> cache = files.stream().map(s -> baseDir.getPath() + "/" + s).collect(Collectors.toSet());
+            // Track both the found files AND the cache directories themselves
+            // This ensures cache invalidation when var/cache is deleted/recreated
+            Set<String> trackedPaths = new HashSet<>();
 
-            return CachedValueProvider.Result.create(Collections.unmodifiableSet(files), new AbsoluteFileModificationTracker(cache));
+            // Add the found container files
+            trackedPaths.addAll(files.stream().map(s -> baseDir.getPath() + "/" + s).collect(Collectors.toSet()));
+
+            // ALWAYS track the cache directories - even if they don't exist
+            // This way, if they're deleted and recreated, the timestamp change will invalidate cache
+            for (String root : new String[] {"var/cache", "app/cache"}) {
+                // Add the expected path even if it doesn't exist yet
+                String rootPath = baseDir.getPath() + "/" + root;
+                trackedPaths.add(rootPath);
+
+                VirtualFile cacheRoot = VfsUtil.findRelativeFile(root, baseDir);
+                if (cacheRoot != null && cacheRoot.exists()) {
+                    // Also track common dev subdirectories (both existing and potentially appearing)
+                    for (String devSubdir : new String[] {"dev", "development", "dev_old"}) {
+                        trackedPaths.add(rootPath + "/" + devSubdir);
+                    }
+
+                    // And track all actually existing dev* subdirectories
+                    for (VirtualFile child : cacheRoot.getChildren()) {
+                        if (child.isDirectory() && child.getName().toLowerCase().startsWith("dev")) {
+                            trackedPaths.add(child.getPath());
+                        }
+                    }
+                }
+            }
+
+            return CachedValueProvider.Result.create(Collections.unmodifiableSet(files), new AbsoluteFileModificationTracker(trackedPaths));
         }, false);
     }
 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/path/ContainerTwigNamespaceExtension.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/path/ContainerTwigNamespaceExtension.java
@@ -1,9 +1,13 @@
 package fr.adrienbrault.idea.symfony2plugin.templating.path;
 
+import fr.adrienbrault.idea.symfony2plugin.dic.ContainerParameter;
 import fr.adrienbrault.idea.symfony2plugin.extension.TwigNamespaceExtension;
 import fr.adrienbrault.idea.symfony2plugin.extension.TwigNamespaceExtensionParameter;
+import fr.adrienbrault.idea.symfony2plugin.stubs.ContainerCollectionResolver;
 import fr.adrienbrault.idea.symfony2plugin.util.service.ServiceXmlParserFactory;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,9 +27,71 @@ public class ContainerTwigNamespaceExtension implements TwigNamespaceExtension {
     @Override
     public Collection<TwigPath> getNamespaces(@NotNull TwigNamespaceExtensionParameter parameter) {
         TwigPathServiceParser twigPathServiceParser = ServiceXmlParserFactory.getInstance(parameter.getProject(), TwigPathServiceParser.class);
+        Collection<TwigPath> twigPaths = twigPathServiceParser.getTwigPathIndex().getTwigPaths();
 
-        return new ArrayList<>(
-            twigPathServiceParser.getTwigPathIndex().getTwigPaths()
-        );
+        // Get kernel.project_dir for Docker/VM path mapping support
+        String kernelProjectDir = getKernelProjectDir(parameter);
+
+        // If no kernel.project_dir found, return paths as-is
+        if (kernelProjectDir == null) {
+            return new ArrayList<>(twigPaths);
+        }
+
+        // Convert absolute container paths to relative paths
+        Collection<TwigPath> convertedPaths = new ArrayList<>();
+        for (TwigPath twigPath : twigPaths) {
+            String path = twigPath.getPath();
+            String convertedPath = convertContainerPathToRelative(path, kernelProjectDir);
+
+            // Create new TwigPath with converted path
+            if (!convertedPath.equals(path)) {
+                convertedPaths.add(TwigPath.createTwigPath(
+                    convertedPath,
+                    twigPath.getNamespace(),
+                    twigPath.getNamespaceType(),
+                    twigPath.isCustomPath(),
+                    twigPath.isEnabled()
+                ));
+            } else {
+                convertedPaths.add(twigPath);
+            }
+        }
+
+        return convertedPaths;
+    }
+
+    /**
+     * Gets kernel.project_dir from cached ParameterCollector.
+     */
+    @Nullable
+    private String getKernelProjectDir(@NotNull TwigNamespaceExtensionParameter parameter) {
+        ContainerParameter containerParameter = ContainerCollectionResolver
+            .getParameters(parameter.getProject())
+            .get("kernel.project_dir");
+
+        if (containerParameter != null) {
+            String value = containerParameter.getValue();
+            return StringUtils.isNotBlank(value) ? value.trim() : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts container/VM absolute paths to relative paths.
+     * Uses kernel.project_dir to determine what should be stripped from paths.
+     */
+    @NotNull
+    private String convertContainerPathToRelative(@NotNull String path, @NotNull String kernelProjectDir) {
+        if (path.startsWith(kernelProjectDir)) {
+            // Remove kernel.project_dir prefix and leading slash
+            String relativePath = StringUtils.stripStart(path.substring(kernelProjectDir.length()), "/");
+            if (StringUtils.isNotBlank(relativePath)) {
+                return relativePath;
+            }
+        }
+
+        // If path doesn't start with kernel.project_dir, return as-is
+        return path;
     }
 }


### PR DESCRIPTION
I am using remote development in my projects, where the Symfony project is executed in a VM or Docker container. Path mapping is in effect, so absolute file paths written  into the container XML dump are not valid on the host OS where the IDE is running.

I noticed that the container XML-based Twig path detection does not work: Templates do not show up in the autocomplete dialog, and the "Twig / Template" plugin settings page shows a lot of blank fields in its table. A look at the code reveals that the path is not printed if it cannot be validated in the host OS.

So, what I think needs to be done is to strip the value of `kernel.project_dir` as a leading component from those paths, in order to obtain project-relative paths that are valid in the host OS as well.

I have no practical experience with Java, I do Symfony and PHP for a living. So, disclaimer: The code change suggested here has been crafted with Claude Code, it need not be a reasonable way to approach the issue.

It consists of two parts:

* One is the path munging itself. It works: Relative paths show up in the plugin settings page with this change, and autocompletion works as well.
* Second is a cache handling issue: When the `var/cache` directory is deleted and later rebuilt, the code would drop into a state where it would no longer read the container file. This has been "fixed" by an extra change, but it may well be that the problem was caused by improper usage of compoents (maybe something like an injected service in a Symfony application?) in the first place.

Please advise if the changes look sane or what I could do to support bringing this forward.


