### PR TITLE
Switch to custom DataExternalizers for stub indexes

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/SerializableService.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/dic/container/SerializableService.java
@@ -89,6 +89,11 @@ public class SerializableService implements ServiceSerializable {
         return this;
     }
 
+    @Nullable
+    public Boolean isPublicNullable() {
+        return isPublic;
+    }
+
     public SerializableService setIsPublic(@Nullable Boolean isPublic) {
         this.isPublic = isPublic;
         return this;
@@ -97,6 +102,11 @@ public class SerializableService implements ServiceSerializable {
     @Override
     public boolean isLazy() {
         return isLazy != null ? isLazy : false;
+    }
+
+    @Nullable
+    public Boolean isLazyNullable() {
+        return isLazy;
     }
 
     public SerializableService setIsLazy(@Nullable Boolean isLazy) {
@@ -109,6 +119,11 @@ public class SerializableService implements ServiceSerializable {
         return isAbstract != null ? isAbstract : false;
     }
 
+    @Nullable
+    public Boolean isAbstractNullable() {
+        return isAbstract;
+    }
+
     public SerializableService setIsAbstract(@Nullable Boolean isAbstract) {
         this.isAbstract = isAbstract;
         return this;
@@ -119,6 +134,11 @@ public class SerializableService implements ServiceSerializable {
         return isAutowire != null ? isAutowire : false;
     }
 
+    @Nullable
+    public Boolean isAutowireNullable() {
+        return isAutowire;
+    }
+
     public SerializableService setIsAutowire(@Nullable Boolean isAutowire) {
         this.isAutowire = isAutowire;
         return this;
@@ -127,6 +147,11 @@ public class SerializableService implements ServiceSerializable {
     @Override
     public boolean isDeprecated() {
         return isDeprecated != null ? isDeprecated : false;
+    }
+
+    @Nullable
+    public Boolean isDeprecatedNullable() {
+        return isDeprecated;
     }
 
     public SerializableService setIsDeprecated(@Nullable Boolean isDeprecated) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ConfigStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ConfigStubIndex.java
@@ -8,7 +8,7 @@ import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.ConfigIndex;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ConfigIndexExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.util.ProjectUtil;
 import fr.adrienbrault.idea.symfony2plugin.util.PsiElementUtils;
 import fr.adrienbrault.idea.symfony2plugin.util.yaml.YamlHelper;
@@ -27,7 +27,7 @@ public class ConfigStubIndex extends FileBasedIndexExtension<String, ConfigIndex
     public static final ID<String, ConfigIndex> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.config_stub_index");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
     private static final int MAX_FILE_BYTE_SIZE = 2097152;
-    private static final ObjectStreamDataExternalizer<ConfigIndex> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final ConfigIndexExternalizer EXTERNALIZER = ConfigIndexExternalizer.INSTANCE;
 
     @NotNull
     @Override
@@ -141,7 +141,7 @@ public class ConfigStubIndex extends FileBasedIndexExtension<String, ConfigIndex
 
     @Override
     public int getVersion() {
-        return 2;
+        return 3;
     }
 
     @Override

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ContainerBuilderStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ContainerBuilderStubIndex.java
@@ -18,7 +18,7 @@ import com.jetbrains.php.lang.psi.elements.MethodReference;
 import com.jetbrains.php.lang.psi.elements.Parameter;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.dict.ContainerBuilderCall;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ContainerBuilderCallExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.util.PhpElementsUtil;
 import fr.adrienbrault.idea.symfony2plugin.util.ProjectUtil;
 import one.util.streamex.StreamEx;
@@ -39,7 +39,7 @@ public class ContainerBuilderStubIndex extends FileBasedIndexExtension<String, C
 
     public static final ID<String, ContainerBuilderCall> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.container_builder");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
-    private final static ObjectStreamDataExternalizer<ContainerBuilderCall> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private final static ContainerBuilderCallExternalizer EXTERNALIZER = ContainerBuilderCallExternalizer.INSTANCE;
 
     private static final int MAX_FILE_BYTE_SIZE = 2621440;
 
@@ -112,7 +112,7 @@ public class ContainerBuilderStubIndex extends FileBasedIndexExtension<String, C
 
     @Override
     public int getVersion() {
-        return 2;
+        return 3;
     }
 
     private static boolean isValidForIndex(FileContent inputData, PsiFile psiFile) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/DoctrineMetadataFileStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/DoctrineMetadataFileStubIndex.java
@@ -10,7 +10,7 @@ import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.doctrine.DoctrineUtil;
 import fr.adrienbrault.idea.symfony2plugin.doctrine.dict.DoctrineModel;
 import fr.adrienbrault.idea.symfony2plugin.doctrine.dict.DoctrineModelSerializable;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.DoctrineModelExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.inputFilter.FileInputFilter;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,7 +25,7 @@ public class DoctrineMetadataFileStubIndex extends FileBasedIndexExtension<Strin
 
     public static final ID<String, DoctrineModelSerializable> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.doctrine_metadata");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
-    private static final ObjectStreamDataExternalizer<DoctrineModelSerializable> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final DoctrineModelExternalizer EXTERNALIZER = DoctrineModelExternalizer.INSTANCE;
 
     private static final int MAX_FILE_BYTE_SIZE = 1048576;
 
@@ -96,7 +96,7 @@ public class DoctrineMetadataFileStubIndex extends FileBasedIndexExtension<Strin
 
     @Override
     public int getVersion() {
-        return 4;
+        return 5;
     }
 
     public static boolean isValidForIndex(FileContent inputData, PsiFile psiFile) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/EventAnnotationStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/EventAnnotationStubIndex.java
@@ -21,7 +21,7 @@ import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.elements.impl.ClassConstImpl;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.DispatcherEvent;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.DispatcherEventExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.stubs.util.EventDispatcherUtil;
 import fr.adrienbrault.idea.symfony2plugin.util.PsiElementUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -37,7 +37,7 @@ public class EventAnnotationStubIndex extends FileBasedIndexExtension<String, Di
 
     public static final ID<String, DispatcherEvent> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.events_annotation");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
-    private static final ObjectStreamDataExternalizer<DispatcherEvent> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final DispatcherEventExternalizer EXTERNALIZER = DispatcherEventExternalizer.INSTANCE;
 
     @NotNull
     @Override
@@ -105,7 +105,7 @@ public class EventAnnotationStubIndex extends FileBasedIndexExtension<String, Di
 
     @Override
     public int getVersion() {
-        return 2;
+        return 3;
     }
 
     private void visitPhpDocTag(@NotNull PhpDocTag element, @NotNull Map<String, DispatcherEvent> map, @NotNull ElementPattern<PsiElement> phpDocAttributeListPattern, @NotNull ElementPattern<PsiElement> phpDocStringPattern) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/FileResourcesIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/FileResourcesIndex.java
@@ -7,7 +7,7 @@ import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.FileResource;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.FileResourceExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.inputFilter.FileInputFilter;
 import fr.adrienbrault.idea.symfony2plugin.util.FileResourceVisitorUtil;
 import org.jetbrains.annotations.NotNull;
@@ -22,7 +22,7 @@ import java.util.Map;
 public class FileResourcesIndex extends FileBasedIndexExtension<String, FileResource> {
 
     private static final int MAX_FILE_BYTE_SIZE = 1048576;
-    private static final ObjectStreamDataExternalizer<FileResource> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final FileResourceExternalizer EXTERNALIZER = FileResourceExternalizer.INSTANCE;
 
     public static final ID<String, FileResource> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.file_resources");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
@@ -80,7 +80,7 @@ public class FileResourcesIndex extends FileBasedIndexExtension<String, FileReso
 
     @Override
     public int getVersion() {
-        return 3;
+        return 4;
     }
 
     public static boolean isValidForIndex(FileContent inputData, PsiFile psiFile) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/PhpTwigTemplateUsageStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/PhpTwigTemplateUsageStubIndex.java
@@ -16,7 +16,7 @@ import com.jetbrains.php.lang.psi.elements.*;
 import com.jetbrains.php.lang.psi.stubs.indexes.PhpConstantNameIndex;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.TemplateUsage;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.TemplateUsageExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.templating.util.PhpMethodVariableResolveUtil;
 import kotlin.Triple;
 import org.apache.commons.lang3.StringUtils;
@@ -33,7 +33,7 @@ public class PhpTwigTemplateUsageStubIndex extends FileBasedIndexExtension<Strin
     public static final ID<String, TemplateUsage> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.twig_php_usage");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
     private static final int MAX_FILE_BYTE_SIZE = 2097152;
-    private static final ObjectStreamDataExternalizer<TemplateUsage> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final TemplateUsageExternalizer EXTERNALIZER = TemplateUsageExternalizer.INSTANCE;
 
     @NotNull
     @Override
@@ -138,7 +138,7 @@ public class PhpTwigTemplateUsageStubIndex extends FileBasedIndexExtension<Strin
 
     @Override
     public int getVersion() {
-        return 3;
+        return 4;
     }
 
     private static boolean isValidForIndex(FileContent inputData) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/RoutesStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/RoutesStubIndex.java
@@ -15,7 +15,7 @@ import com.jetbrains.php.lang.psi.elements.PhpClass;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.routing.RouteHelper;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.StubIndexedRoute;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.StubIndexedRouteExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.inputFilter.FileInputFilter;
 import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.visitor.AnnotationRouteElementVisitor;
 import fr.adrienbrault.idea.symfony2plugin.util.ProjectUtil;
@@ -33,7 +33,7 @@ public class RoutesStubIndex extends FileBasedIndexExtension<String, StubIndexed
 
     public static final ID<String, StubIndexedRoute> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.routes_object");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
-    private static final ObjectStreamDataExternalizer<StubIndexedRoute> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final StubIndexedRouteExternalizer EXTERNALIZER = StubIndexedRouteExternalizer.INSTANCE;
 
     @NotNull
     @Override
@@ -119,7 +119,7 @@ public class RoutesStubIndex extends FileBasedIndexExtension<String, StubIndexed
 
     @Override
     public int getVersion() {
-        return 4;
+        return 5;
     }
 
     private static boolean isValidForIndex(FileContent inputData, PsiFile psiFile) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ServicesDefinitionStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/ServicesDefinitionStubIndex.java
@@ -9,7 +9,7 @@ import com.intellij.util.io.KeyDescriptor;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.ServiceSerializable;
 import fr.adrienbrault.idea.symfony2plugin.dic.container.util.ServiceContainerUtil;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.SerializableServiceExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.inputFilter.FileInputFilter;
 import fr.adrienbrault.idea.symfony2plugin.util.ProjectUtil;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +28,7 @@ public class ServicesDefinitionStubIndex extends FileBasedIndexExtension<String,
 
     public static final ID<String, ServiceSerializable> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.service_definition");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
-    private static final ObjectStreamDataExternalizer<ServiceSerializable> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final SerializableServiceExternalizer EXTERNALIZER = SerializableServiceExternalizer.INSTANCE;
 
     @NotNull
     @Override
@@ -82,7 +82,7 @@ public class ServicesDefinitionStubIndex extends FileBasedIndexExtension<String,
 
     @Override
     public int getVersion() {
-        return 7;
+        return 8;
     }
 
     public static boolean isValidForIndex(FileContent inputData, PsiFile psiFile) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/StimulusControllerStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/StimulusControllerStubIndex.java
@@ -21,7 +21,7 @@ import com.intellij.util.io.DataExternalizer;
 import com.intellij.util.io.EnumeratorStringDescriptor;
 import com.intellij.util.io.KeyDescriptor;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.StimulusController;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.StimulusControllerExternalizer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,7 +37,7 @@ import java.util.*;
  */
 public class StimulusControllerStubIndex extends FileBasedIndexExtension<String, StimulusController> {
     public static final ID<String, StimulusController> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.stimulus_controller_index");
-    private static final ObjectStreamDataExternalizer<StimulusController> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final StimulusControllerExternalizer EXTERNALIZER = StimulusControllerExternalizer.INSTANCE;
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
 
     @Override
@@ -437,7 +437,7 @@ public class StimulusControllerStubIndex extends FileBasedIndexExtension<String,
 
     @Override
     public int getVersion() {
-        return 6;
+        return 7;
     }
 
     @Override

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/TwigIncludeStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/TwigIncludeStubIndex.java
@@ -9,7 +9,7 @@ import com.jetbrains.twig.TwigFile;
 import com.jetbrains.twig.TwigFileType;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.TemplateInclude;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.TemplateIncludeExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.templating.util.TwigUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,7 +23,7 @@ public class TwigIncludeStubIndex extends FileBasedIndexExtension<String, Templa
 
     public static final ID<String, TemplateInclude> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.twig_include_tags");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
-    private static final ObjectStreamDataExternalizer<TemplateInclude> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final TemplateIncludeExternalizer EXTERNALIZER = TemplateIncludeExternalizer.INSTANCE;
 
     @NotNull
     @Override
@@ -83,7 +83,7 @@ public class TwigIncludeStubIndex extends FileBasedIndexExtension<String, Templa
 
     @Override
     public int getVersion() {
-        return 4;
+        return 5;
     }
 
 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/TwigMacroFunctionStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/TwigMacroFunctionStubIndex.java
@@ -9,7 +9,7 @@ import com.jetbrains.twig.TwigFile;
 import com.jetbrains.twig.TwigFileType;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.TwigMacroTagIndex;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.TwigMacroTagIndexExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.templating.util.TwigUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,7 +23,7 @@ public class TwigMacroFunctionStubIndex extends FileBasedIndexExtension<String, 
 
     public static final ID<String, TwigMacroTagIndex> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.twig_macro_function");
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
-    private static final ObjectStreamDataExternalizer<TwigMacroTagIndex> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final TwigMacroTagIndexExternalizer EXTERNALIZER = TwigMacroTagIndexExternalizer.INSTANCE;
 
     @NotNull
     @Override
@@ -83,7 +83,7 @@ public class TwigMacroFunctionStubIndex extends FileBasedIndexExtension<String, 
 
     @Override
     public int getVersion() {
-        return 3;
+        return 4;
     }
 }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/UxTemplateStubIndex.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/UxTemplateStubIndex.java
@@ -7,7 +7,7 @@ import com.intellij.util.io.KeyDescriptor;
 import com.jetbrains.php.lang.psi.PhpFile;
 import com.jetbrains.php.lang.psi.stubs.indexes.PhpConstantNameIndex;
 import fr.adrienbrault.idea.symfony2plugin.stubs.dict.UxComponent;
-import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.ObjectStreamDataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer.UxComponentExternalizer;
 import fr.adrienbrault.idea.symfony2plugin.util.UxUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public class UxTemplateStubIndex extends FileBasedIndexExtension<String, UxComponent> {
     public static final ID<String, UxComponent> KEY = ID.create("fr.adrienbrault.idea.symfony2plugin.ux_template_index");
-    private static final ObjectStreamDataExternalizer<UxComponent> EXTERNALIZER = new ObjectStreamDataExternalizer<>();
+    private static final UxComponentExternalizer EXTERNALIZER = UxComponentExternalizer.INSTANCE;
 
     private final KeyDescriptor<String> myKeyDescriptor = new EnumeratorStringDescriptor();
     @Override
@@ -52,7 +52,7 @@ public class UxTemplateStubIndex extends FileBasedIndexExtension<String, UxCompo
 
     @Override
     public int getVersion() {
-        return 3;
+        return 4;
     }
 
     public FileBasedIndex.@NotNull InputFilter getInputFilter() {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/ConfigIndexExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/ConfigIndexExternalizer.java
@@ -1,0 +1,64 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.ConfigIndex;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class ConfigIndexExternalizer implements DataExternalizer<ConfigIndex> {
+
+    public static final ConfigIndexExternalizer INSTANCE = new ConfigIndexExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, ConfigIndex value) throws IOException {
+        out.writeUTF(value.getName());
+        TreeMap<String, TreeMap<String, String>> configs = (TreeMap<String, TreeMap<String, String>>) value.getConfigs();
+        out.writeInt(configs.size());
+        for (Map.Entry<String, TreeMap<String, String>> entry : configs.entrySet()) {
+            out.writeUTF(entry.getKey());
+            TreeMap<String, String> inner = entry.getValue();
+            out.writeInt(inner.size());
+            for (Map.Entry<String, String> innerEntry : inner.entrySet()) {
+                out.writeUTF(innerEntry.getKey());
+                out.writeUTF(innerEntry.getValue());
+            }
+        }
+        Set<String> values = value.getValues();
+        out.writeInt(values.size());
+        for (String v : values) {
+            out.writeUTF(v);
+        }
+    }
+
+    @Override
+    public ConfigIndex read(@NotNull DataInput in) throws IOException {
+        String name = in.readUTF();
+        int configsSize = in.readInt();
+        TreeMap<String, TreeMap<String, String>> configs = new TreeMap<>();
+        for (int i = 0; i < configsSize; i++) {
+            String key = in.readUTF();
+            int innerSize = in.readInt();
+            TreeMap<String, String> inner = new TreeMap<>();
+            for (int j = 0; j < innerSize; j++) {
+                inner.put(in.readUTF(), in.readUTF());
+            }
+            configs.put(key, inner);
+        }
+        int valuesSize = in.readInt();
+        Set<String> values = new HashSet<>(valuesSize);
+        for (int i = 0; i < valuesSize; i++) {
+            values.add(in.readUTF());
+        }
+        return new ConfigIndex(name, configs, values);
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/ContainerBuilderCallExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/ContainerBuilderCallExternalizer.java
@@ -1,0 +1,56 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.dic.container.dict.ContainerBuilderCall;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class ContainerBuilderCallExternalizer implements DataExternalizer<ContainerBuilderCall> {
+
+    public static final ContainerBuilderCallExternalizer INSTANCE = new ContainerBuilderCallExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, ContainerBuilderCall value) throws IOException {
+        writeNullableString(out, value.getScope());
+        writeNullableString(out, value.getName());
+        Collection<String> parameter = value.getParameter();
+        if (parameter == null) {
+            out.writeInt(0);
+        } else {
+            out.writeInt(parameter.size());
+            for (String p : parameter) {
+                out.writeUTF(p);
+            }
+        }
+    }
+
+    @Override
+    public ContainerBuilderCall read(@NotNull DataInput in) throws IOException {
+        ContainerBuilderCall call = new ContainerBuilderCall();
+        call.setScope(readNullableString(in));
+        call.setName(readNullableString(in));
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            call.addParameter(in.readUTF());
+        }
+        return call;
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/DispatcherEventExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/DispatcherEventExternalizer.java
@@ -1,0 +1,45 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.DispatcherEvent;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class DispatcherEventExternalizer implements DataExternalizer<DispatcherEvent> {
+
+    public static final DispatcherEventExternalizer INSTANCE = new DispatcherEventExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, DispatcherEvent value) throws IOException {
+        writeNullableString(out, value.getFqn());
+        writeNullableString(out, value.getInstance());
+    }
+
+    @Override
+    public DispatcherEvent read(@NotNull DataInput in) throws IOException {
+        String fqn = readNullableString(in);
+        String instance = readNullableString(in);
+        DispatcherEvent event = new DispatcherEvent();
+        if (fqn != null) {
+            return new DispatcherEvent(fqn, instance);
+        }
+        return event;
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/DoctrineModelExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/DoctrineModelExternalizer.java
@@ -1,0 +1,41 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.doctrine.dict.DoctrineModel;
+import fr.adrienbrault.idea.symfony2plugin.doctrine.dict.DoctrineModelSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class DoctrineModelExternalizer implements DataExternalizer<DoctrineModelSerializable> {
+
+    public static final DoctrineModelExternalizer INSTANCE = new DoctrineModelExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, DoctrineModelSerializable value) throws IOException {
+        out.writeUTF(value.getClassName());
+        writeNullableString(out, value.getRepositoryClass());
+        writeNullableString(out, value.getTableName());
+    }
+
+    @Override
+    public DoctrineModelSerializable read(@NotNull DataInput in) throws IOException {
+        return new DoctrineModel(in.readUTF(), readNullableString(in), readNullableString(in));
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/FileResourceExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/FileResourceExternalizer.java
@@ -1,0 +1,70 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.FileResource;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.FileResourceContextTypeEnum;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class FileResourceExternalizer implements DataExternalizer<FileResource> {
+
+    public static final FileResourceExternalizer INSTANCE = new FileResourceExternalizer();
+
+    private static final FileResourceContextTypeEnum[] CONTEXT_TYPE_VALUES = FileResourceContextTypeEnum.values();
+
+    @Override
+    public void save(@NotNull DataOutput out, FileResource value) throws IOException {
+        writeNullableString(out, value.getResource());
+        FileResourceContextTypeEnum contextType = value.getContextType();
+        out.writeBoolean(contextType != null);
+        if (contextType != null) {
+            out.writeByte(contextType.ordinal());
+        }
+        TreeMap<String, String> contextValues = value.getContextValues();
+        out.writeBoolean(contextValues != null);
+        if (contextValues != null) {
+            out.writeInt(contextValues.size());
+            for (Map.Entry<String, String> entry : contextValues.entrySet()) {
+                out.writeUTF(entry.getKey());
+                out.writeUTF(entry.getValue());
+            }
+        }
+    }
+
+    @Override
+    public FileResource read(@NotNull DataInput in) throws IOException {
+        String resource = readNullableString(in);
+        FileResourceContextTypeEnum contextType = null;
+        if (in.readBoolean()) {
+            contextType = CONTEXT_TYPE_VALUES[in.readByte()];
+        }
+        TreeMap<String, String> contextValues = null;
+        if (in.readBoolean()) {
+            int size = in.readInt();
+            contextValues = new TreeMap<>();
+            for (int i = 0; i < size; i++) {
+                contextValues.put(in.readUTF(), in.readUTF());
+            }
+        }
+        return new FileResource(resource, contextType, contextValues);
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/SerializableServiceExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/SerializableServiceExternalizer.java
@@ -1,0 +1,103 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.dic.container.SerializableService;
+import fr.adrienbrault.idea.symfony2plugin.dic.container.ServiceSerializable;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class SerializableServiceExternalizer implements DataExternalizer<ServiceSerializable> {
+
+    public static final SerializableServiceExternalizer INSTANCE = new SerializableServiceExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, ServiceSerializable value) throws IOException {
+        if (!(value instanceof SerializableService service)) {
+            throw new IOException("Unexpected type: " + value.getClass());
+        }
+        out.writeUTF(service.getId());
+        writeNullableString(out, service.getClassName());
+        writeNullableBoolean(out, service.isPublicNullable());
+        writeNullableBoolean(out, service.isLazyNullable());
+        writeNullableBoolean(out, service.isAbstractNullable());
+        writeNullableBoolean(out, service.isAutowireNullable());
+        writeNullableBoolean(out, service.isDeprecatedNullable());
+        writeNullableString(out, service.getAlias());
+        writeNullableString(out, service.getDecorates());
+        writeNullableString(out, service.getDecorationInnerName());
+        writeNullableString(out, service.getParent());
+        writeStringCollection(out, service.getResource());
+        writeStringCollection(out, service.getExclude());
+        writeStringCollection(out, service.getTags());
+    }
+
+    @Override
+    public SerializableService read(@NotNull DataInput in) throws IOException {
+        SerializableService service = new SerializableService(in.readUTF());
+        service.setClassName(readNullableString(in));
+        service.setIsPublic(readNullableBoolean(in));
+        service.setIsLazy(readNullableBoolean(in));
+        service.setIsAbstract(readNullableBoolean(in));
+        service.setIsAutowire(readNullableBoolean(in));
+        service.setIsDeprecated(readNullableBoolean(in));
+        service.setAlias(readNullableString(in));
+        service.setDecorates(readNullableString(in));
+        service.setDecorationInnerName(readNullableString(in));
+        service.setParent(readNullableString(in));
+        service.setResource(readStringCollection(in));
+        service.setExclude(readStringCollection(in));
+        service.setTags(readStringCollection(in));
+        return service;
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+
+    private static void writeNullableBoolean(@NotNull DataOutput out, Boolean value) throws IOException {
+        if (value == null) {
+            out.writeByte(0);
+        } else if (value) {
+            out.writeByte(1);
+        } else {
+            out.writeByte(2);
+        }
+    }
+
+    private static Boolean readNullableBoolean(@NotNull DataInput in) throws IOException {
+        byte b = in.readByte();
+        if (b == 0) return null;
+        return b == 1;
+    }
+
+    private static void writeStringCollection(@NotNull DataOutput out, Collection<String> values) throws IOException {
+        out.writeInt(values.size());
+        for (String value : values) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static Collection<String> readStringCollection(@NotNull DataInput in) throws IOException {
+        int size = in.readInt();
+        Collection<String> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            result.add(in.readUTF());
+        }
+        return result;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/StimulusControllerExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/StimulusControllerExternalizer.java
@@ -1,0 +1,45 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.StimulusController;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class StimulusControllerExternalizer implements DataExternalizer<StimulusController> {
+
+    public static final StimulusControllerExternalizer INSTANCE = new StimulusControllerExternalizer();
+
+    private static final StimulusController.SourceType[] SOURCE_TYPE_VALUES = StimulusController.SourceType.values();
+
+    @Override
+    public void save(@NotNull DataOutput out, StimulusController value) throws IOException {
+        out.writeUTF(value.name());
+        out.writeByte(value.sourceType().ordinal());
+        writeNullableString(out, value.originalName());
+    }
+
+    @Override
+    public StimulusController read(@NotNull DataInput in) throws IOException {
+        String name = in.readUTF();
+        StimulusController.SourceType sourceType = SOURCE_TYPE_VALUES[in.readByte()];
+        String originalName = readNullableString(in);
+        return new StimulusController(name, sourceType, originalName);
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/StubIndexedRouteExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/StubIndexedRouteExternalizer.java
@@ -1,0 +1,56 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.StubIndexedRoute;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class StubIndexedRouteExternalizer implements DataExternalizer<StubIndexedRoute> {
+
+    public static final StubIndexedRouteExternalizer INSTANCE = new StubIndexedRouteExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, StubIndexedRoute value) throws IOException {
+        out.writeUTF(value.getName());
+        writeNullableString(out, value.getController());
+        writeNullableString(out, value.getPath());
+        Collection<String> methods = value.getMethods();
+        out.writeInt(methods.size());
+        for (String method : methods) {
+            out.writeUTF(method);
+        }
+    }
+
+    @Override
+    public StubIndexedRoute read(@NotNull DataInput in) throws IOException {
+        StubIndexedRoute route = new StubIndexedRoute(in.readUTF());
+        route.setController(readNullableString(in));
+        route.setPath(readNullableString(in));
+        int size = in.readInt();
+        Collection<String> methods = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            methods.add(in.readUTF());
+        }
+        route.setMethods(methods);
+        return route;
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/TemplateIncludeExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/TemplateIncludeExternalizer.java
@@ -1,0 +1,41 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.TemplateInclude;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import static fr.adrienbrault.idea.symfony2plugin.templating.dict.TemplateInclude.TYPE;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class TemplateIncludeExternalizer implements DataExternalizer<TemplateInclude> {
+
+    public static final TemplateIncludeExternalizer INSTANCE = new TemplateIncludeExternalizer();
+
+    private static final TYPE[] TYPE_VALUES = TYPE.values();
+
+    @Override
+    public void save(@NotNull DataOutput out, TemplateInclude value) throws IOException {
+        out.writeUTF(value.getTemplate());
+        TYPE type = value.getType();
+        out.writeBoolean(type != null);
+        if (type != null) {
+            out.writeByte(type.ordinal());
+        }
+    }
+
+    @Override
+    public TemplateInclude read(@NotNull DataInput in) throws IOException {
+        String template = in.readUTF();
+        TYPE type = null;
+        if (in.readBoolean()) {
+            type = TYPE_VALUES[in.readByte()];
+        }
+        return new TemplateInclude(template, type != null ? type : TYPE.INCLUDE);
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/TemplateUsageExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/TemplateUsageExternalizer.java
@@ -1,0 +1,40 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.TemplateUsage;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class TemplateUsageExternalizer implements DataExternalizer<TemplateUsage> {
+
+    public static final TemplateUsageExternalizer INSTANCE = new TemplateUsageExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, TemplateUsage value) throws IOException {
+        out.writeUTF(value.getTemplate());
+        Collection<String> scopes = value.getScopes();
+        out.writeInt(scopes.size());
+        for (String scope : scopes) {
+            out.writeUTF(scope);
+        }
+    }
+
+    @Override
+    public TemplateUsage read(@NotNull DataInput in) throws IOException {
+        String template = in.readUTF();
+        int size = in.readInt();
+        Collection<String> scopes = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            scopes.add(in.readUTF());
+        }
+        return new TemplateUsage(template, scopes);
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/TwigMacroTagIndexExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/TwigMacroTagIndexExternalizer.java
@@ -1,0 +1,39 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.TwigMacroTagIndex;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class TwigMacroTagIndexExternalizer implements DataExternalizer<TwigMacroTagIndex> {
+
+    public static final TwigMacroTagIndexExternalizer INSTANCE = new TwigMacroTagIndexExternalizer();
+
+    @Override
+    public void save(@NotNull DataOutput out, TwigMacroTagIndex value) throws IOException {
+        out.writeUTF(value.name());
+        writeNullableString(out, value.parameters());
+    }
+
+    @Override
+    public TwigMacroTagIndex read(@NotNull DataInput in) throws IOException {
+        return new TwigMacroTagIndex(in.readUTF(), readNullableString(in));
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/UxComponentExternalizer.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/stubs/indexes/externalizer/UxComponentExternalizer.java
@@ -1,0 +1,48 @@
+package fr.adrienbrault.idea.symfony2plugin.stubs.indexes.externalizer;
+
+import com.intellij.util.io.DataExternalizer;
+import fr.adrienbrault.idea.symfony2plugin.stubs.dict.UxComponent;
+import fr.adrienbrault.idea.symfony2plugin.util.UxUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+public class UxComponentExternalizer implements DataExternalizer<UxComponent> {
+
+    public static final UxComponentExternalizer INSTANCE = new UxComponentExternalizer();
+
+    private static final UxUtil.TwigComponentType[] TYPE_VALUES = UxUtil.TwigComponentType.values();
+
+    @Override
+    public void save(@NotNull DataOutput out, UxComponent value) throws IOException {
+        writeNullableString(out, value.name());
+        out.writeUTF(value.phpClass());
+        writeNullableString(out, value.template());
+        out.writeByte(value.type().ordinal());
+    }
+
+    @Override
+    public UxComponent read(@NotNull DataInput in) throws IOException {
+        String name = readNullableString(in);
+        String phpClass = in.readUTF();
+        String template = readNullableString(in);
+        UxUtil.TwigComponentType type = TYPE_VALUES[in.readByte()];
+        return new UxComponent(name, phpClass, template, type);
+    }
+
+    private static void writeNullableString(@NotNull DataOutput out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) {
+            out.writeUTF(value);
+        }
+    }
+
+    private static String readNullableString(@NotNull DataInput in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+}


### PR DESCRIPTION
Switch several stub indexes to use custom `DataExternalizer` implementations (e.g., `ConfigIndexExternalizer`, `ContainerBuilderCallExternalizer`) instead of the generic `ObjectStreamDataExternalizer`.