### PR TITLE
Wire TwigFileUsage into missing-template inspection

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigPattern.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigPattern.java
@@ -194,6 +194,8 @@ public class TwigPattern {
         )
         .withLanguage(TwigLanguage.INSTANCE);
 
+    private static final ElementPattern<PsiElement> CACHED_INCLUDE_SOURCE_PRINT_BLOCK_OR_TAG_FUNCTION_PATTERN = getPrintBlockOrTagFunctionPattern("include", "source");
+
     private static final ElementPattern<PsiElement> CACHED_FUNCTION_STRING_PARAMETER_PATTERN = PlatformPatterns
         .psiElement(TwigTokenTypes.STRING_TEXT)
         .afterLeafSkipping(
@@ -886,6 +888,13 @@ public class TwigPattern {
      */
     public static ElementPattern<PsiElement> getPrintBlockOrTagFunctionPattern() {
         return CACHED_PRINT_BLOCK_OR_TAG_FUNCTION_PATTERN;
+    }
+
+    /**
+     * Check for {{ include('|') }}, {% include('|') %}, {{ source('|') }}, {% source('|') %}.
+     */
+    public static ElementPattern<PsiElement> getIncludeSourcePrintBlockOrTagFunctionPattern() {
+        return CACHED_INCLUDE_SOURCE_PRINT_BLOCK_OR_TAG_FUNCTION_PATTERN;
     }
 
     /**

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigTemplateCompletionContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigTemplateCompletionContributor.java
@@ -83,7 +83,7 @@ public class TwigTemplateCompletionContributor extends CompletionContributor {
 
         // all file template "include" pattern
         extend(CompletionType.BASIC, PlatformPatterns.or(
-            TwigPattern.getPrintBlockOrTagFunctionPattern("include", "source"),
+            TwigPattern.getIncludeSourcePrintBlockOrTagFunctionPattern(),
             TwigPattern.getPrintBlockOrTagFunctionSecondParameterPattern("block"),
             TwigPattern.getIncludeTagArrayPattern(),
             TwigPattern.getTagTernaryPattern(TwigElementTypes.INCLUDE_TAG)
@@ -861,7 +861,7 @@ public class TwigTemplateCompletionContributor extends CompletionContributor {
                 prioritizedKeys.addAll(TwigUtil.getExtendsTemplateUsageAsOrderedList(project));
             } else if (TwigPattern.getTemplateFileReferenceTagPattern("embed").accepts(psiElement)) {
                 prioritizedKeys.addAll(TwigUtil.getEmbedTemplateUsageAsOrderedList(project));
-            } else if (TwigPattern.getTemplateFileReferenceTagPattern("include").accepts(psiElement) || TwigPattern.getPrintBlockOrTagFunctionPattern("include", "source").accepts(psiElement)) {
+            } else if (TwigPattern.getTemplateFileReferenceTagPattern("include").accepts(psiElement) || TwigPattern.getIncludeSourcePrintBlockOrTagFunctionPattern().accepts(psiElement)) {
                 prioritizedKeys.addAll(TwigUtil.getIncludeTemplateUsageAsOrderedList(project));
             }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigTemplateGoToDeclarationHandler.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/TwigTemplateGoToDeclarationHandler.java
@@ -66,7 +66,7 @@ public class TwigTemplateGoToDeclarationHandler implements GotoDeclarationHandle
         }
 
         if (TwigPattern.getTemplateFileReferenceTagPattern().accepts(psiElement)
-            || TwigPattern.getPrintBlockOrTagFunctionPattern("include", "source").accepts(psiElement)
+            || TwigPattern.getIncludeSourcePrintBlockOrTagFunctionPattern().accepts(psiElement)
             || TwigPattern.getPrintBlockOrTagFunctionSecondParameterPattern("block").accepts(psiElement))
         {
             // support: {% include() %}, {{ include() }}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/inspection/TwigTemplateMissingInspection.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/inspection/TwigTemplateMissingInspection.java
@@ -2,7 +2,6 @@ package fr.adrienbrault.idea.symfony2plugin.templating.inspection;
 
 import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.LocalQuickFix;
-import com.intellij.patterns.ElementPattern;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -11,7 +10,6 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.jetbrains.twig.TwigTokenTypes;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
-import fr.adrienbrault.idea.symfony2plugin.templating.TwigPattern;
 import fr.adrienbrault.idea.symfony2plugin.templating.util.TwigUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -41,33 +39,22 @@ public class TwigTemplateMissingInspection extends LocalInspectionTool {
         @NotNull
         private final ProblemsHolder holder;
 
-        private ElementPattern<?> templateFileReferencePattern;
-        private ElementPattern<?> includeFunctionPattern;
-
         MyPsiElementVisitor(@NotNull ProblemsHolder holder) {
             this.holder = holder;
         }
 
         @Override
-        public void visitElement(PsiElement element) {
+        public void visitElement(@NotNull PsiElement element) {
             if (!(element instanceof LeafPsiElement) || element.getNode().getElementType() != TwigTokenTypes.STRING_TEXT) {
                 super.visitElement(element);
                 return;
             }
 
-            if((getTemplateFileReferencePattern().accepts(element) || getIncludeFunctionPattern().accepts(element)) && TwigUtil.isValidStringWithoutInterpolatedOrConcat(element)) {
+            if(TwigUtil.isStaticTemplateUsage(element)) {
                 invoke(element, holder);
             }
 
             super.visitElement(element);
-        }
-
-        private ElementPattern<?> getTemplateFileReferencePattern() {
-            return templateFileReferencePattern != null ? templateFileReferencePattern : (templateFileReferencePattern = TwigPattern.getTemplateFileReferenceTagPattern());
-        }
-
-        private ElementPattern<?> getIncludeFunctionPattern() {
-            return includeFunctionPattern != null ? includeFunctionPattern : (includeFunctionPattern = TwigPattern.getPrintBlockOrTagFunctionPattern("include", "source"));
         }
     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/usages/TwigTemplateUsageTypeProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/usages/TwigTemplateUsageTypeProvider.java
@@ -88,7 +88,7 @@ public class TwigTemplateUsageTypeProvider implements UsageTypeProviderEx {
         if (hasTagName(element, "include")
             || hasPatternMatch(element, TwigPattern.getTagNameParameterPattern(TwigElementTypes.INCLUDE_TAG, "include"))
             || hasPatternMatch(element, TwigPattern.getIncludeTagArrayPattern())
-            || hasPatternMatch(element, TwigPattern.getPrintBlockOrTagFunctionPattern("include", "source"))
+            || hasPatternMatch(element, TwigPattern.getIncludeSourcePrintBlockOrTagFunctionPattern())
             || hasPatternMatch(element, TwigPattern.getPrintBlockOrTagFunctionSecondParameterPattern("block"))) {
             return INCLUDE;
         }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/util/TwigUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/util/TwigUtil.java
@@ -1273,6 +1273,66 @@ public class TwigUtil {
     }
 
     /**
+     * Matches static Twig string leaves that are known template references.
+     *
+     * <pre>{@code
+     * {% include 'base.html.twig' %}
+     * {{ include('base.html.twig') }}
+     * {% custom_template 'base.html.twig' %}
+     * }</pre>
+     *
+     * Dynamic strings such as {@code {% include 'base/' ~ name ~ '.html.twig' %}} are ignored.
+     *
+     * @see #isTemplateUsage(PsiElement)
+     */
+    public static boolean isStaticTemplateUsage(@NotNull PsiElement element) {
+        return isValidStringWithoutInterpolatedOrConcat(element) && isTemplateUsage(element);
+    }
+
+    /**
+     * Matches Twig string leaves that are template references from built-in Twig patterns or external providers.
+     *
+     * <pre>{@code
+     * {% extends 'layout.html.twig' %}
+     * {{ source('snippet.html.twig') }}
+     * {% custom_template 'layout.html.twig' %}
+     * }</pre>
+     *
+     * This method only checks whether the leaf is a template usage. Use {@link #isStaticTemplateUsage(PsiElement)}
+     * when interpolated or concatenated strings must be filtered out.
+     */
+    public static boolean isTemplateUsage(@NotNull PsiElement element) {
+        if (element.getNode() == null || element.getNode().getElementType() != TwigTokenTypes.STRING_TEXT) {
+            return false;
+        }
+
+        return isBuiltInTemplateUsage(element) || isExternalTemplateUsage(element);
+    }
+
+    private static boolean isBuiltInTemplateUsage(@NotNull PsiElement element) {
+        return TwigPattern.getTemplateFileReferenceTagPattern().accepts(element)
+            || TwigPattern.getIncludeSourcePrintBlockOrTagFunctionPattern().accepts(element);
+    }
+
+    private static boolean isExternalTemplateUsage(@NotNull PsiElement stringText) {
+        PsiElement tag = PsiTreeUtil.findFirstParent(stringText, true, parent ->
+            parent.getNode() != null && parent.getNode().getElementType() == TwigElementTypes.TAG
+        );
+
+        if (tag == null) {
+            return false;
+        }
+
+        for (TwigFileUsage extension : TWIG_FILE_USAGE_EXTENSIONS.getExtensions()) {
+            if (extension.isTemplateFileReference(tag)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Find file in a twig path collection
      *
      * @param project current project
@@ -2548,7 +2608,7 @@ public class TwigUtil {
     public static class TemplateIncludePatterns {
         final ElementPattern<PsiElement> importTag = TwigPattern.getTagNameParameterPattern(TwigElementTypes.IMPORT_TAG, "import");
         final ElementPattern<PsiElement> fromTag = TwigPattern.getTagNameParameterPattern(TwigElementTypes.IMPORT_TAG, "from");
-        final ElementPattern<PsiElement> includeSource = TwigPattern.getPrintBlockOrTagFunctionPattern("include", "source");
+        final ElementPattern<PsiElement> includeSource = TwigPattern.getIncludeSourcePrintBlockOrTagFunctionPattern();
         final ElementPattern<PsiElement> blockFunctionTemplate = TwigPattern.getPrintBlockOrTagFunctionSecondParameterPattern("block");
         final ElementPattern<PsiElement> embed = TwigPattern.getEmbedPattern();
         final ElementPattern<PsiElement> tagName = PlatformPatterns.psiElement().withElementType(TwigTokenTypes.TAG_NAME);

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/TestTwigFileUsage.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/TestTwigFileUsage.java
@@ -1,0 +1,50 @@
+package fr.adrienbrault.idea.symfony2plugin.tests.templating;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.twig.TwigTokenTypes;
+import com.jetbrains.twig.elements.TwigElementTypes;
+import fr.adrienbrault.idea.symfony2plugin.extension.TwigFileUsage;
+import fr.adrienbrault.idea.symfony2plugin.util.PsiElementUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class TestTwigFileUsage implements TwigFileUsage {
+    @Override
+    public Collection<String> getExtendsTemplate(@NotNull PsiElement psiElement) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<String> getIncludeTemplate(@NotNull PsiElement psiElement) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isExtendsTemplate(@NotNull PsiElement psiElement) {
+        return false;
+    }
+
+    @Override
+    public boolean isIncludeTemplate(@NotNull PsiElement psiElement) {
+        return false;
+    }
+
+    @Override
+    public boolean isTemplateFileReference(@NotNull PsiElement psiElement) {
+        return isTag(psiElement, "custom_template");
+    }
+
+    private static boolean isTag(@NotNull PsiElement psiElement, @NotNull String name) {
+        if (psiElement.getNode().getElementType() == TwigElementTypes.TAG) {
+            PsiElement tagElement = PsiElementUtils.getChildrenOfType(psiElement, PlatformPatterns.psiElement().withElementType(TwigTokenTypes.TAG_NAME));
+            if (tagElement != null) {
+                return name.equals(tagElement.getText());
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/inspection/TwigTemplateMissingInspectionTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/inspection/TwigTemplateMissingInspectionTest.java
@@ -1,12 +1,21 @@
 package fr.adrienbrault.idea.symfony2plugin.tests.templating.inspection;
 
 import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+import fr.adrienbrault.idea.symfony2plugin.tests.templating.TestTwigFileUsage;
+import fr.adrienbrault.idea.symfony2plugin.templating.util.TwigUtil;
 
 /**
  * @author Daniel Espendiller <daniel@espendiller.net>
  * @see fr.adrienbrault.idea.symfony2plugin.templating.inspection.TwigTemplateMissingInspection
  */
 public class TwigTemplateMissingInspectionTest extends SymfonyLightCodeInsightFixtureTestCase {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        TwigUtil.TWIG_FILE_USAGE_EXTENSIONS.getPoint().registerExtension(new TestTwigFileUsage(), getTestRootDisposable());
+    }
+
     public void testThatUnknownTemplatesAreHighlighted() {
         assertLocalInspectionContains(
             "test.html.twig",
@@ -39,6 +48,25 @@ public class TwigTemplateMissingInspectionTest extends SymfonyLightCodeInsightFi
         );
     }
 
+    public void testThatExternalTemplateUsageUnknownTemplatesAreHighlighted() {
+        assertLocalInspectionContains(
+            "test.html.twig",
+            "{% custom_template 'missing<caret>.html.twig' %}",
+            "Twig: Missing Template"
+        );
+    }
+
+    public void testThatExternalTemplateUsageExistingTemplatesAreNotHighlighted() {
+        myFixture.addFileToProject("ide-twig.json", "{ \"namespaces\": [{ \"namespace\": \"\", \"path\": \"templates\" }] }");
+        myFixture.addFileToProject("templates/existing.html.twig", "");
+
+        assertLocalInspectionNotContains(
+            "test.html.twig",
+            "{% custom_template 'existing<caret>.html.twig' %}",
+            "Twig: Missing Template"
+        );
+    }
+
     public void testThatInvalidTemplateNamesAreNotHighlighted() {
         assertLocalInspectionNotContains(
             "test.html.twig",
@@ -61,6 +89,20 @@ public class TwigTemplateMissingInspectionTest extends SymfonyLightCodeInsightFi
         assertLocalInspectionNotContains(
             "test.html.twig",
             "{% include 'fo<caret>#{segment.typeKey}.html.twig' %}",
+            "Twig: Missing Template"
+        );
+    }
+
+    public void testThatExternalTemplateUsageInvalidTemplateNamesAreNotHighlighted() {
+        assertLocalInspectionNotContains(
+            "test.html.twig",
+            "{% custom_template \"foo/\" ~ segment.typeKey ~ \".ht<caret>ml.twig\" %}",
+            "Twig: Missing Template"
+        );
+
+        assertLocalInspectionNotContains(
+            "test.html.twig",
+            "{% custom_template 'fo<caret>#{segment}.html.twig' %}",
             "Twig: Missing Template"
         );
     }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/util/TwigUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/util/TwigUtilTest.java
@@ -13,6 +13,7 @@ import fr.adrienbrault.idea.symfony2plugin.templating.TwigPattern;
 import fr.adrienbrault.idea.symfony2plugin.templating.path.TwigNamespaceSetting;
 import fr.adrienbrault.idea.symfony2plugin.templating.util.TwigUtil;
 import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+import fr.adrienbrault.idea.symfony2plugin.tests.templating.TestTwigFileUsage;
 import fr.adrienbrault.idea.symfony2plugin.util.yaml.YamlPsiElementFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.yaml.psi.YAMLFile;
@@ -31,6 +32,7 @@ public class TwigUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
     public void setUp() throws Exception {
         super.setUp();
         Settings.getInstance(getProject()).twigNamespaces.clear();
+        TwigUtil.TWIG_FILE_USAGE_EXTENSIONS.getPoint().registerExtension(new TestTwigFileUsage(), getTestRootDisposable());
     }
 
     /**
@@ -188,6 +190,40 @@ public class TwigUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         assertNull(TwigUtil.findTwigFunctionSecondArgumentPathLeaf(findConstantStringArgument("{{ constant('CLUBS', factory()) }}")));
     }
 
+    /**
+     * @see TwigUtil#isTemplateUsage(PsiElement)
+     */
+    public void testIsTemplateUsage() {
+        PsiElement includeTagString = findCaretElement("{% include 'foo<caret>.html.twig' %}");
+        assertTrue(TwigUtil.isTemplateUsage(includeTagString));
+
+        PsiElement includeFunctionString = findCaretElement("{{ include('foo<caret>.html.twig') }}");
+        assertTrue(TwigUtil.isTemplateUsage(includeFunctionString));
+
+        PsiElement customTemplateString = findCaretElement("{% custom_template 'foo<caret>.html.twig' %}");
+        assertTrue(TwigUtil.isTemplateUsage(customTemplateString));
+
+        PsiElement plainString = findCaretElement("{{ 'foo<caret>.html.twig' }}");
+        assertFalse(TwigUtil.isTemplateUsage(plainString));
+    }
+
+    /**
+     * @see TwigUtil#isStaticTemplateUsage(PsiElement)
+     */
+    public void testIsStaticTemplateUsage() {
+        PsiElement includeTagString = findCaretElement("{% include 'foo<caret>.html.twig' %}");
+        assertTrue(TwigUtil.isStaticTemplateUsage(includeTagString));
+
+        PsiElement includeFunctionString = findCaretElement("{{ include('foo<caret>.html.twig') }}");
+        assertTrue(TwigUtil.isStaticTemplateUsage(includeFunctionString));
+
+        PsiElement customTemplateString = findCaretElement("{% custom_template 'foo<caret>.html.twig' %}");
+        assertTrue(TwigUtil.isStaticTemplateUsage(customTemplateString));
+
+        PsiElement dynamicTemplateString = findCaretElement("{% include 'foo<caret>#{bar}.html.twig' %}");
+        assertFalse(TwigUtil.isStaticTemplateUsage(dynamicTemplateString));
+    }
+
     @NotNull
     static List<TwigNamespaceSetting> createTwigNamespaceSettings() {
         return Arrays.asList(
@@ -207,6 +243,15 @@ public class TwigUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
 
         assertNotNull(pathLeaf);
         assertEquals(expectedName, pathLeaf.getText());
+    }
+
+    @NotNull
+    private PsiElement findCaretElement(@NotNull String template) {
+        myFixture.configureByText(TwigFileType.INSTANCE, template);
+        PsiElement element = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+        assertNotNull(element);
+
+        return element;
     }
 
     @NotNull


### PR DESCRIPTION
Summary:
- make TwigTemplateMissingInspection ask registered TwigFileUsage providers for tag-based template usages
- pass the surrounding Twig TAG element to providers while keeping diagnostics anchored on STRING_TEXT
- add generic synthetic-provider coverage for missing, existing, and dynamic external tag targets
