### PR TITLE
Add syntax highlighting, hover documentation and completion for Symfony UX Toolkit component docblocks

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
@@ -1,0 +1,150 @@
+package fr.adrienbrault.idea.symfony2plugin.templating.annotation;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.php.lang.highlighter.PhpHighlightingData;
+import com.jetbrains.twig.TwigTokenTypes;
+import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Provides syntax highlighting for Symfony UX Toolkit Twig comment annotations.
+ *
+ * Supports:
+ * - {# @prop name type Description #}
+ * - {# @block name Description #}
+ *
+ * Uses PHP's PHPDoc highlighting colors for consistency with `@property` annotations.
+ *
+ * @see <a href="https://github.com/symfony/ux-toolkit">Symfony UX Toolkit</a>
+ */
+public class TwigUxToolkitAnnotator implements Annotator {
+    /**
+     * Pattern for @prop annotations.
+     * Format: @prop name type Description
+     * Example: @prop open boolean Whether the item is open by default.
+     *
+     * Supports complex types:
+     * - Simple: string, boolean, int
+     * - Nullable: ?string, string|null
+     * - Union: string|int|null
+     * - Generic: array<string>, Collection<int, Item>
+     * - Literal strings: 'vertical'|'horizontal'
+     * - FQCN: App\Entity\Item, \DateTime
+     * - Arrays: string[], Item[]
+     *
+     * @see <a href="https://regex101.com/r/3JXNX7/1">Regex101</a>
+     */
+    private static final Pattern PROP_PATTERN = Pattern.compile(
+        "(@prop)\\s+(\\w+)\\s+(\\S+)\\s+(.+?)\\s*$",
+        Pattern.DOTALL
+    );
+
+    /**
+     * Pattern for @block annotations.
+     * Format: @block name Description
+     * Example: @block content The item content.
+     *
+     * @see <a href="https://regex101.com/r/jYjXpq/1">Regex101</a>
+     */
+    private static final Pattern BLOCK_PATTERN = Pattern.compile(
+        "(@block)\\s+(\\w+)\\s+(.+?)\\s*$",
+        Pattern.DOTALL
+    );
+
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (!Symfony2ProjectComponent.isEnabled(element.getProject())) {
+            return;
+        }
+
+        // Only process Twig comment text tokens
+        if (element.getNode().getElementType() != TwigTokenTypes.COMMENT_TEXT) {
+            return;
+        }
+
+        String text = element.getText();
+        int startOffset = element.getTextRange().getStartOffset();
+
+        // Try to match @prop pattern
+        Matcher propMatcher = PROP_PATTERN.matcher(text);
+        if (propMatcher.find()) {
+            annotateProp(holder, startOffset, propMatcher);
+            return;
+        }
+
+        // Try to match @block pattern
+        Matcher blockMatcher = BLOCK_PATTERN.matcher(text);
+        if (blockMatcher.find()) {
+            annotateBlock(holder, startOffset, blockMatcher);
+        }
+    }
+
+    /**
+     * Annotates a @prop comment with syntax highlighting.
+     * Highlights: @prop keyword, property name, and type.
+     *
+     * Uses PHP PHPDoc colors:
+     * - DOC_TAG for @prop keyword (like @property in PHPDoc)
+     * - DOC_PROPERTY_IDENTIFIER for property name (like $foo in @property string $foo)
+     * - DOC_IDENTIFIER for type (like string in @property string $foo)
+     */
+    private void annotateProp(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher) {
+        // Highlight @prop keyword (group 1) - like @property
+        highlightRange(holder, startOffset, matcher, 1, PhpHighlightingData.DOC_TAG);
+
+        // Highlight property name (group 2) - like $foo in @property string $foo
+        highlightRange(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER);
+
+        // Highlight type (group 3) - like string in @property string $foo
+        highlightRange(holder, startOffset, matcher, 3, PhpHighlightingData.DOC_IDENTIFIER);
+    }
+
+    /**
+     * Annotates a @block comment with syntax highlighting.
+     * Highlights: @block keyword and block name.
+     *
+     * Uses PHP PHPDoc colors:
+     * - DOC_TAG for @block keyword
+     * - DOC_PROPERTY_IDENTIFIER for block name
+     */
+    private void annotateBlock(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher) {
+        // Highlight @block keyword (group 1)
+        highlightRange(holder, startOffset, matcher, 1, PhpHighlightingData.DOC_TAG);
+
+        // Highlight block name (group 2)
+        highlightRange(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER);
+    }
+
+    /**
+     * Creates a silent annotation with the specified text attributes for a regex group match.
+     */
+    private void highlightRange(
+        @NotNull AnnotationHolder holder,
+        int baseOffset,
+        @NotNull Matcher matcher,
+        int group,
+        @NotNull TextAttributesKey textAttributesKey
+    ) {
+        if (matcher.group(group) == null) {
+            return;
+        }
+
+        TextRange range = new TextRange(
+            baseOffset + matcher.start(group),
+            baseOffset + matcher.end(group)
+        );
+
+        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .range(range)
+            .textAttributes(textAttributesKey)
+            .create();
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
@@ -5,12 +5,21 @@ import com.intellij.lang.annotation.Annotator;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.CachedValueProvider;
+import com.intellij.psi.util.CachedValuesManager;
 import com.jetbrains.php.lang.highlighter.PhpHighlightingData;
+import com.jetbrains.twig.TwigFile;
 import com.jetbrains.twig.TwigTokenTypes;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
+import fr.adrienbrault.idea.symfony2plugin.util.UxUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,27 +35,6 @@ import java.util.regex.Pattern;
  * @see <a href="https://github.com/symfony/ux-toolkit">Symfony UX Toolkit</a>
  */
 public class TwigUxToolkitAnnotator implements Annotator {
-    /**
-     * Pattern for @prop annotations.
-     * Format: @prop name type Description
-     * Example: @prop open boolean Whether the item is open by default.
-     *
-     * Supports complex types:
-     * - Simple: string, boolean, int
-     * - Nullable: ?string, string|null
-     * - Union: string|int|null
-     * - Generic: array<string>, Collection<int, Item>
-     * - Literal strings: 'vertical'|'horizontal'
-     * - FQCN: App\Entity\Item, \DateTime
-     * - Arrays: string[], Item[]
-     *
-     * @see <a href="https://regex101.com/r/3JXNX7/1">Regex101</a>
-     */
-    private static final Pattern PROP_PATTERN = Pattern.compile(
-        "(@prop)\\s+(\\w+)\\s+(\\S+)\\s+(.+?)\\s*$",
-        Pattern.DOTALL
-    );
-
     /**
      * Pattern for @block annotations.
      * Format: @block name Description
@@ -74,9 +62,9 @@ public class TwigUxToolkitAnnotator implements Annotator {
         int startOffset = element.getTextRange().getStartOffset();
 
         // Try to match @prop pattern
-        Matcher propMatcher = PROP_PATTERN.matcher(text);
+        Matcher propMatcher = UxUtil.PROP_PATTERN.matcher(text);
         if (propMatcher.find()) {
-            annotateProp(holder, startOffset, propMatcher);
+            annotateProp(holder, startOffset, propMatcher, getPropDefaults(element));
             return;
         }
 
@@ -95,16 +83,88 @@ public class TwigUxToolkitAnnotator implements Annotator {
      * - DOC_TAG for @prop keyword (like @property in PHPDoc)
      * - DOC_PROPERTY_IDENTIFIER for property name (like $foo in @property string $foo)
      * - DOC_IDENTIFIER for type (like string in @property string $foo)
+     *
+     * The property name also carries a hover tooltip with its type, default value (sourced from the
+     * {@code {% props %}} tag, the single source of truth for defaults) and description.
      */
-    private void annotateProp(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher) {
+    private void annotateProp(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher, @NotNull Map<String, String> propDefaults) {
         // Highlight @prop keyword (group 1) - like @property
         highlightRange(holder, startOffset, matcher, 1, PhpHighlightingData.DOC_TAG);
 
-        // Highlight property name (group 2) - like $foo in @property string $foo
-        highlightRange(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER);
+        // Highlight property name (group 2) - like $foo in @property string $foo - with a hover tooltip
+        String name = matcher.group(2);
+        String defaultValue = name != null ? propDefaults.get(name) : null;
+        String tooltip = buildPropTooltip(name, matcher.group(3), matcher.group(4), defaultValue);
+        highlightRangeWithTooltip(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER, tooltip);
 
         // Highlight type (group 3) - like string in @property string $foo
         highlightRange(holder, startOffset, matcher, 3, PhpHighlightingData.DOC_IDENTIFIER);
+    }
+
+    /**
+     * Reads the prop default values declared in the template's {@code {% props %}} tag, cached per file.
+     */
+    private static @NotNull Map<String, String> getPropDefaults(@NotNull PsiElement element) {
+        PsiFile file = element.getContainingFile();
+        if (!(file instanceof TwigFile twigFile)) {
+            return Collections.emptyMap();
+        }
+
+        return CachedValuesManager.getCachedValue(twigFile, () ->
+            CachedValueProvider.Result.create(UxUtil.getComponentTemplatePropDefaults(twigFile), twigFile)
+        );
+    }
+
+    /**
+     * Builds the hover tooltip for a prop: {@code name : type = default} followed by its description.
+     */
+    private static @NotNull String buildPropTooltip(@Nullable String name, @Nullable String type, @Nullable String description, @Nullable String defaultValue) {
+        StringBuilder tooltip = new StringBuilder();
+
+        if (name != null) {
+            tooltip.append("<code>").append(StringUtil.escapeXmlEntities(name)).append("</code>");
+        }
+
+        if (type != null) {
+            tooltip.append(" : <code>").append(StringUtil.escapeXmlEntities(type)).append("</code>");
+        }
+
+        if (defaultValue != null) {
+            tooltip.append(" = <code>").append(StringUtil.escapeXmlEntities(defaultValue)).append("</code>");
+        }
+
+        if (description != null && !description.isBlank()) {
+            tooltip.append("<br/>").append(StringUtil.escapeXmlEntities(description.trim().replaceAll("\\s+", " ")));
+        }
+
+        return tooltip.toString();
+    }
+
+    /**
+     * Like {@link #highlightRange} but attaches a hover tooltip (which {@code newSilentAnnotation} cannot carry).
+     */
+    private void highlightRangeWithTooltip(
+        @NotNull AnnotationHolder holder,
+        int baseOffset,
+        @NotNull Matcher matcher,
+        int group,
+        @NotNull TextAttributesKey textAttributesKey,
+        @NotNull String tooltip
+    ) {
+        if (matcher.group(group) == null) {
+            return;
+        }
+
+        TextRange range = new TextRange(
+            baseOffset + matcher.start(group),
+            baseOffset + matcher.end(group)
+        );
+
+        holder.newAnnotation(HighlightSeverity.INFORMATION, StringUtil.removeHtmlTags(tooltip))
+            .range(range)
+            .tooltip(tooltip)
+            .textAttributes(textAttributesKey)
+            .create();
     }
 
     /**

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/completion/TwigHtmlCompletionContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/completion/TwigHtmlCompletionContributor.java
@@ -16,6 +16,7 @@ import com.intellij.util.Consumer;
 import com.intellij.util.ProcessingContext;
 import com.jetbrains.php.lang.psi.elements.PhpClass;
 import com.jetbrains.php.lang.psi.elements.PhpNamedElement;
+import com.jetbrains.twig.TwigFile;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2Icons;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.asset.AssetDirectoryReader;
@@ -363,7 +364,9 @@ public class TwigHtmlCompletionContributor extends CompletionContributor {
             new CompletionProvider<>() {
                 @Override
                 protected void addCompletions(@NotNull CompletionParameters parameters, @NotNull ProcessingContext processingContext, @NotNull CompletionResultSet resultSet) {
-                    PsiElement position = parameters.getOriginalPosition();
+                    // use getPosition() (never null) so completion also fires right after "<twig:Alert <caret>",
+                    // where getOriginalPosition() is null (caret on whitespace / not yet on an attribute).
+                    PsiElement position = parameters.getPosition();
                     if (!Symfony2ProjectComponent.isEnabled(position)) {
                         return;
                     }
@@ -398,19 +401,34 @@ public class TwigHtmlCompletionContributor extends CompletionContributor {
                         });
                     }
 
-                    // Add completion for {% props %} defined in component templates
+                    // Add completion for {% props %} defined in component templates, showing the prop
+                    // type (from its {# @prop #} docblock) on the right when available.
                     String componentName = name.substring(5);
+
+                    Map<String, String> propTypes = new HashMap<>();
+                    for (PsiFile template : UxUtil.getComponentTemplates(position.getProject(), componentName)) {
+                        if (template instanceof TwigFile twigFile) {
+                            UxUtil.getComponentTemplateProps(twigFile).forEach((propName, prop) -> propTypes.putIfAbsent(propName, prop.type()));
+                        }
+                    }
+
                     UxUtil.visitComponentTemplateProps(position.getProject(), componentName, (Consumer<Pair<String, PsiElement>>) pair -> {
+                        String type = propTypes.get(pair.getFirst());
+
                         LookupElementBuilder element1 = LookupElementBuilder
                             .create(pair.getFirst())
                             .withIcon(Symfony2Icons.SYMFONY);
-
+                        if (type != null) {
+                            element1 = element1.withTypeText(type, true);
+                        }
                         resultSet.addElement(element1);
 
                         LookupElementBuilder element2 = LookupElementBuilder
                             .create(":" + pair.getFirst())
                             .withIcon(Symfony2Icons.SYMFONY);
-
+                        if (type != null) {
+                            element2 = element2.withTypeText(type, true);
+                        }
                         resultSet.addElement(element2);
                     });
                 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/documentation/TwigComponentAttributeDocumentationProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/documentation/TwigComponentAttributeDocumentationProvider.java
@@ -1,0 +1,136 @@
+package fr.adrienbrault.idea.symfony2plugin.templating.documentation;
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlTag;
+import com.jetbrains.twig.TwigFile;
+import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
+import fr.adrienbrault.idea.symfony2plugin.util.UxUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Documentation for Symfony UX Twig component props on their usage, e.g. Ctrl-hover / Ctrl-Q on the
+ * {@code variant} attribute of {@code <twig:Alert variant="">}. The prop's type and description come
+ * from the component template's {@code {# @prop #}} docblock and its default value from the
+ * {@code {%- props -%}} tag ({@link UxUtil#getComponentTemplateProps}).
+ *
+ * <p>Registered for HTML because the {@code <twig:...>} attribute leaf is HTML in the {@code .html.twig}
+ * view. Returns {@code null} for anything that is not a {@code twig:} component attribute, so the
+ * platform's built-in HTML documentation still applies elsewhere.
+ */
+public class TwigComponentAttributeDocumentationProvider extends AbstractDocumentationProvider {
+
+    private static final String TWIG_TAG_PREFIX = "twig:";
+
+    @Override
+    public @Nullable PsiElement getCustomDocumentationElement(@NotNull Editor editor, @NotNull PsiFile file, @Nullable PsiElement contextElement, int targetOffset) {
+        if (!Symfony2ProjectComponent.isEnabled(file.getProject())) {
+            return null;
+        }
+
+        // The context leaf is usually the HTML attribute token already; otherwise look through every
+        // language root of the templated .html.twig file (the `<twig:...>` markup lives in the HTML root).
+        XmlAttribute attribute = findTwigComponentAttribute(contextElement);
+        if (attribute != null) {
+            return attribute;
+        }
+
+        for (PsiFile root : file.getViewProvider().getAllFiles()) {
+            attribute = findTwigComponentAttribute(root.findElementAt(targetOffset));
+            if (attribute != null) {
+                return attribute;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public @Nullable String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
+        UxUtil.TwigComponentProp prop = resolveProp(element);
+        if (prop == null) {
+            return null;
+        }
+
+        StringBuilder doc = new StringBuilder();
+        doc.append("<code>").append(escape(prop.name())).append("</code>")
+            .append(" : <code>").append(escape(prop.type())).append("</code>");
+
+        if (prop.defaultValue() != null) {
+            doc.append("<br/>Default: <code>").append(escape(prop.defaultValue())).append("</code>");
+        }
+
+        if (!prop.description().isBlank()) {
+            doc.append("<br/><br/>").append(escape(prop.description()));
+        }
+
+        return doc.toString();
+    }
+
+    @Override
+    public @Nullable String getQuickNavigateInfo(PsiElement element, PsiElement originalElement) {
+        UxUtil.TwigComponentProp prop = resolveProp(element);
+        if (prop == null) {
+            return null;
+        }
+
+        StringBuilder info = new StringBuilder();
+        info.append("<code>").append(escape(prop.name())).append("</code>")
+            .append(" : <code>").append(escape(prop.type())).append("</code>");
+
+        if (prop.defaultValue() != null) {
+            info.append(" = <code>").append(escape(prop.defaultValue())).append("</code>");
+        }
+
+        return info.toString();
+    }
+
+    private static @Nullable UxUtil.TwigComponentProp resolveProp(@Nullable PsiElement element) {
+        XmlAttribute attribute = findTwigComponentAttribute(element);
+        if (attribute == null || !(attribute.getParent() instanceof XmlTag tag)) {
+            return null;
+        }
+
+        Project project = attribute.getProject();
+        if (!Symfony2ProjectComponent.isEnabled(project)) {
+            return null;
+        }
+
+        String componentName = tag.getName().substring(TWIG_TAG_PREFIX.length());
+        String attributeName = StringUtils.stripStart(attribute.getName(), ":");
+
+        for (PsiFile template : UxUtil.getComponentTemplates(project, componentName)) {
+            if (template instanceof TwigFile twigFile) {
+                UxUtil.TwigComponentProp prop = UxUtil.getComponentTemplateProps(twigFile).get(attributeName);
+                if (prop != null) {
+                    return prop;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static @Nullable XmlAttribute findTwigComponentAttribute(@Nullable PsiElement element) {
+        XmlAttribute attribute = PsiTreeUtil.getParentOfType(element, XmlAttribute.class, false);
+        if (attribute != null
+            && attribute.getParent() instanceof XmlTag tag
+            && tag.getName().startsWith(TWIG_TAG_PREFIX)) {
+            return attribute;
+        }
+
+        return null;
+    }
+
+    private static String escape(@NotNull String text) {
+        return StringUtil.escapeXmlEntities(text);
+    }
+}

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
@@ -18,6 +18,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.CachedValue;
 import com.intellij.psi.util.CachedValueProvider;
 import com.intellij.psi.util.CachedValuesManager;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.indexing.FileBasedIndex;
 import com.jetbrains.php.lang.psi.PhpFile;
 import com.jetbrains.php.lang.psi.elements.*;
@@ -49,6 +50,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -936,6 +938,39 @@ public class UxUtil {
         "(@prop)\\s+(\\w+)\\s+(\\S+)\\s+(.+?)\\s*$",
         Pattern.DOTALL
     );
+
+    /**
+     * A prop documented in a component template: its {@code {# @prop name type description #}} docblock
+     * merged with the default value declared in the {@code {%- props -%}} tag.
+     */
+    public record TwigComponentProp(@NotNull String name, @NotNull String type, @NotNull String description, @Nullable String defaultValue) {}
+
+    /**
+     * Parses a component template's {@code {# @prop name type description #}} docblocks and merges each
+     * prop's default value from the {@code {%- props -%}} tag ({@link #getComponentTemplatePropDefaults}).
+     *
+     * @return prop name to its documentation, in docblock order
+     */
+    @NotNull
+    public static Map<String, TwigComponentProp> getComponentTemplateProps(@NotNull TwigFile twigFile) {
+        Map<String, String> defaults = getComponentTemplatePropDefaults(twigFile);
+        Map<String, TwigComponentProp> props = new LinkedHashMap<>();
+
+        for (PsiElement comment : PsiTreeUtil.collectElements(twigFile, element -> element.getNode().getElementType() == TwigTokenTypes.COMMENT_TEXT)) {
+            Matcher matcher = PROP_PATTERN.matcher(comment.getText());
+            if (matcher.find()) {
+                String name = matcher.group(2);
+                props.put(name, new TwigComponentProp(
+                    name,
+                    matcher.group(3),
+                    matcher.group(4).trim().replaceAll("\\s+", " "),
+                    defaults.get(name)
+                ));
+            }
+        }
+
+        return props;
+    }
 
 
     private static Collection<String> getExposeName(@NotNull PhpAttributesOwner phpAttributesOwner) {

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.formatter.FormatterUtil;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.CachedValue;
 import com.intellij.psi.util.CachedValueProvider;
 import com.intellij.psi.util.CachedValuesManager;
@@ -48,6 +49,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -830,6 +832,110 @@ public class UxUtil {
             }
         }
     }
+
+    /**
+     * Extracts the prop default values from a component template's {@code {%- props -%}} tag.
+     *
+     * <p>Default values live only in the {@code {%- props -%}} declaration (the single source of
+     * truth), the same way Symfony UX Toolkit's {@code ComponentDocParser} sources them rather than
+     * from the {@code {# @prop #}} docblock. Each default is returned as written in the source
+     * (e.g. {@code false}, {@code 'brand'}, {@code ['a', 'b']}); commas inside arrays, hashes and
+     * strings are handled because the Twig parser nests them, so only the tag's top-level commas
+     * separate props. Props declared without a default (required props) are not included.
+     *
+     * @return prop name to its default expression, in declaration order
+     */
+    @NotNull
+    public static Map<String, String> getComponentTemplatePropDefaults(@NotNull TwigFile twigFile) {
+        Map<String, String> defaults = new LinkedHashMap<>();
+
+        for (PsiElement element : twigFile.getChildren()) {
+            if (!(element instanceof TwigCompositeElement) || element.getNode().getElementType() != TwigElementTypes.TAG) {
+                continue;
+            }
+
+            ASTNode[] children = element.getNode().getChildren(null);
+
+            int nameIndex = -1;
+            for (int i = 0; i < children.length; i++) {
+                if (children[i].getElementType() == TwigTokenTypes.TAG_NAME) {
+                    nameIndex = i;
+                    break;
+                }
+            }
+
+            if (nameIndex == -1 || !"props".equals(children[nameIndex].getText().trim())) {
+                continue;
+            }
+
+            List<ASTNode> segment = new ArrayList<>();
+            for (int i = nameIndex + 1; i < children.length; i++) {
+                IElementType type = children[i].getElementType();
+                if (type == TwigTokenTypes.STATEMENT_BLOCK_END) {
+                    break;
+                }
+
+                if (type == TwigTokenTypes.COMMA) {
+                    collectPropDefault(segment, defaults);
+                    segment.clear();
+                } else {
+                    segment.add(children[i]);
+                }
+            }
+            collectPropDefault(segment, defaults);
+
+            return defaults;
+        }
+
+        return defaults;
+    }
+
+    private static void collectPropDefault(@NotNull List<ASTNode> segment, @NotNull Map<String, String> defaults) {
+        String name = null;
+        int equalIndex = -1;
+
+        for (int i = 0; i < segment.size(); i++) {
+            ASTNode node = segment.get(i);
+            if (node.getText().isBlank()) {
+                continue;
+            }
+
+            if (name == null) {
+                if (node.getElementType() != TwigTokenTypes.IDENTIFIER) {
+                    return;
+                }
+                name = node.getText();
+            } else if (node.getElementType() == TwigTokenTypes.EQ) {
+                equalIndex = i;
+                break;
+            }
+        }
+
+        if (name == null || equalIndex == -1) {
+            return;
+        }
+
+        StringBuilder defaultValue = new StringBuilder();
+        for (int i = equalIndex + 1; i < segment.size(); i++) {
+            defaultValue.append(segment.get(i).getText());
+        }
+
+        String trimmed = defaultValue.toString().trim();
+        if (!trimmed.isEmpty()) {
+            defaults.put(name, trimmed);
+        }
+    }
+
+    /**
+     * Pattern for a Symfony UX Toolkit {@code {# @prop name type description #}} docblock.
+     * Group 1: {@code @prop}, group 2: name, group 3: type, group 4: description.
+     *
+     * @see <a href="https://regex101.com/r/3JXNX7/1">Regex101</a>
+     */
+    public static final Pattern PROP_PATTERN = Pattern.compile(
+        "(@prop)\\s+(\\w+)\\s+(\\S+)\\s+(.+?)\\s*$",
+        Pattern.DOTALL
+    );
 
 
     private static Collection<String> getExposeName(@NotNull PhpAttributesOwner phpAttributesOwner) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -234,6 +234,8 @@
         <lang.foldingBuilder language="PHP" implementationClass="fr.adrienbrault.idea.symfony2plugin.navigation.PhpFoldingBuilder"/>
         <lang.foldingBuilder language="Twig" implementationClass="fr.adrienbrault.idea.symfony2plugin.navigation.TwigFoldingBuilder"/>
 
+        <annotator language="Twig" implementationClass="fr.adrienbrault.idea.symfony2plugin.templating.annotation.TwigUxToolkitAnnotator"/>
+
         <completion.contributor language="any" implementationClass="fr.adrienbrault.idea.symfony2plugin.codeInsight.completion.CompletionContributor"/>
         <gotoDeclarationHandler implementation="fr.adrienbrault.idea.symfony2plugin.codeInsight.navigation.GotoHandler"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -245,6 +245,7 @@
         <annotator language="Twig" implementationClass="fr.adrienbrault.idea.symfony2plugin.templating.annotation.TwigVarCommentAnnotator"/>
         <completion.contributor language="Twig" implementationClass="fr.adrienbrault.idea.symfony2plugin.templating.TwigTemplateCompletionContributor"/>
         <completion.contributor language="HTML" implementationClass="fr.adrienbrault.idea.symfony2plugin.templating.completion.TwigHtmlCompletionContributor"/>
+        <lang.documentationProvider language="HTML" implementationClass="fr.adrienbrault.idea.symfony2plugin.templating.documentation.TwigComponentAttributeDocumentationProvider"/>
         <completion.contributor language="yaml" implementationClass="fr.adrienbrault.idea.symfony2plugin.config.yaml.YamlCompletionContributor"/>
         <completion.contributor language="yaml" implementationClass="fr.adrienbrault.idea.symfony2plugin.completion.yaml.YamlCompletionContributor"/>
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
@@ -173,6 +173,54 @@ public class TwigUxToolkitAnnotatorTest extends SymfonyLightCodeInsightFixtureTe
         );
     }
 
+    public void testPropTooltipShowsDefaultFromPropsTag() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}\n" +
+            "{%- props open = false -%}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected a tooltip carrying the type, default value and description",
+            highlighting.stream().anyMatch(info ->
+                info.getToolTip() != null
+                    && info.getToolTip().contains("boolean")
+                    && info.getToolTip().contains("false")
+                    && info.getToolTip().contains("Whether the item is open by default.")
+            )
+        );
+    }
+
+    public void testPropTooltipOmitsDefaultForRequiredProp() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop id string Unique identifier. #}\n" +
+            "{%- props id -%}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // the tooltip still describes the prop...
+        assertTrue(
+            "Expected a tooltip carrying the type and description",
+            highlighting.stream().anyMatch(info ->
+                info.getToolTip() != null
+                    && info.getToolTip().contains("string")
+                    && info.getToolTip().contains("Unique identifier.")
+            )
+        );
+
+        // ...but shows no default assignment for a required prop
+        assertFalse(
+            "A required prop must not show a default value",
+            highlighting.stream().anyMatch(info ->
+                info.getToolTip() != null && info.getToolTip().contains("= <code>")
+            )
+        );
+    }
+
     /**
      * Helper method to check if a HighlightInfo has a specific TextAttributesKey.
      */

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
@@ -1,0 +1,187 @@
+package fr.adrienbrault.idea.symfony2plugin.tests.templating.annotation;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.jetbrains.php.lang.highlighter.PhpHighlightingData;
+import fr.adrienbrault.idea.symfony2plugin.templating.annotation.TwigUxToolkitAnnotator;
+import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+
+import java.util.List;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ * @see TwigUxToolkitAnnotator
+ */
+public class TwigUxToolkitAnnotatorTest extends SymfonyLightCodeInsightFixtureTestCase {
+
+    public void testPropAnnotationIsHighlighted() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // Verify that highlighting is applied (INFORMATION level annotations from our annotator)
+        assertTrue(
+            "Expected highlighting for @prop annotation",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    public void testPropAnnotationHighlightsPropertyName() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for property name",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testPropAnnotationHighlightsType() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop open boolean Whether the item is open by default. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for type",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testBlockAnnotationIsHighlighted() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @block content The item content. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for @block annotation",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    public void testBlockAnnotationHighlightsBlockName() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @block content The item content. #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for block name",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testPropWithComplexType() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop items App\\Entity\\Item[] List of items #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for complex type",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testPropWithUnionType() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @prop value string|int|null The value #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        assertTrue(
+            "Expected highlighting for union type",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
+            )
+        );
+    }
+
+    public void testRegularCommentNotHighlighted() {
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# This is a regular comment #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // Regular comments should not have our specific highlighting
+        assertFalse(
+            "Regular comments should not have DOC_COMMENT_TAG highlighting",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    public void testVarCommentNotAffected() {
+        // @var comments are handled by a different mechanism, ensure we don't interfere
+        myFixture.configureByText(
+            "test.html.twig",
+            "{# @var foo \\App\\Entity\\Foo #}"
+        );
+
+        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+
+        // @var must not receive @prop/@block highlighting from TwigUxToolkitAnnotator.
+        // (@var is coloured by the separate TwigVarCommentAnnotator, which uses different keys;
+        // DOC_PROPERTY_IDENTIFIER is unique to a @prop name, so its absence proves we did not fire.)
+        assertFalse(
+            "@var comments should not be highlighted by TwigUxToolkitAnnotator",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
+            )
+        );
+    }
+
+    /**
+     * Helper method to check if a HighlightInfo has a specific TextAttributesKey.
+     */
+    private boolean hasTextAttributesKey(HighlightInfo info, TextAttributesKey expectedKey) {
+        if (info.forcedTextAttributesKey != null) {
+            return info.forcedTextAttributesKey.equals(expectedKey) ||
+                   info.forcedTextAttributesKey.getFallbackAttributeKey() != null &&
+                   info.forcedTextAttributesKey.getFallbackAttributeKey().equals(expectedKey);
+        }
+        return false;
+    }
+}

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/completion/TwigHtmlCompletionContributorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/completion/TwigHtmlCompletionContributorTest.java
@@ -108,4 +108,39 @@ public class TwigHtmlCompletionContributorTest extends SymfonyLightCodeInsightFi
         );
     }
 
+    /**
+     * Test that a template prop's type (from its {# @prop #} docblock) is shown on the right.
+     */
+    public void testThatTemplatePropCompletionShowsTypeFromPropDocblock() {
+        myFixture.copyFileToProject("twig_component.yaml", "config/packages/twig_component.yaml");
+        myFixture.copyFileToProject("ide-twig.json", "ide-twig.json");
+        myFixture.addFileToProject("templates/components/PropsAlert.html.twig",
+            "{# @prop variant 'default'|'destructive' The visual style variant. #}\n" +
+            "{%- props variant = 'default' -%}\n" +
+            "<div></div>"
+        );
+
+        assertCompletionLookupContainsPresentableItem(
+            TwigFileType.INSTANCE,
+            "<twig:PropsAlert <caret> />",
+            presentation -> "variant".equals(presentation.getItemText()) && "'default'|'destructive'".equals(presentation.getTypeText())
+        );
+    }
+
+    /**
+     * Test that prop completion also fires right after "<twig:PropsAlert <caret>" (caret on whitespace,
+     * incomplete tag) where getOriginalPosition() is null.
+     */
+    public void testThatPropCompletionFiresRightAfterTagNameWhitespace() {
+        myFixture.copyFileToProject("twig_component.yaml", "config/packages/twig_component.yaml");
+        myFixture.copyFileToProject("ide-twig.json", "ide-twig.json");
+        myFixture.copyFileToProject("PropsAlert.html.twig", "templates/components/PropsAlert.html.twig");
+
+        assertCompletionContains(
+            TwigFileType.INSTANCE,
+            "<twig:PropsAlert <caret>",
+            "icon", "type", "message"
+        );
+    }
+
 }

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/documentation/TwigComponentAttributeDocumentationProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/documentation/TwigComponentAttributeDocumentationProviderTest.java
@@ -1,0 +1,56 @@
+package fr.adrienbrault.idea.symfony2plugin.tests.templating.documentation;
+
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.twig.TwigFileType;
+import fr.adrienbrault.idea.symfony2plugin.templating.documentation.TwigComponentAttributeDocumentationProvider;
+import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
+
+/**
+ * @see fr.adrienbrault.idea.symfony2plugin.templating.documentation.TwigComponentAttributeDocumentationProvider
+ */
+public class TwigComponentAttributeDocumentationProviderTest extends SymfonyLightCodeInsightFixtureTestCase {
+    public String getTestDataPath() {
+        return "src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/fixtures";
+    }
+
+    public void testDocumentationForTwigComponentAttribute() {
+        myFixture.copyFileToProject("PropsAlert.php", "src/PropsAlert.php");
+        myFixture.copyFileToProject("twig_component.yaml", "config/packages/twig_component.yaml");
+        myFixture.copyFileToProject("ide-twig.json", "ide-twig.json");
+        myFixture.addFileToProject("templates/components/PropsAlert.html.twig",
+            "{# @prop variant 'default'|'destructive' The visual style variant. #}\n" +
+            "{%- props variant = 'default' -%}\n" +
+            "<div></div>"
+        );
+
+        myFixture.configureByText(TwigFileType.INSTANCE, "<twig:PropsAlert varia<caret>nt=\"\" />");
+        int offset = myFixture.getCaretOffset();
+
+        TwigComponentAttributeDocumentationProvider provider = new TwigComponentAttributeDocumentationProvider();
+        PsiElement docElement = provider.getCustomDocumentationElement(
+            myFixture.getEditor(), myFixture.getFile(), myFixture.getFile().findElementAt(offset), offset
+        );
+
+        assertNotNull("Expected a documentation element for a <twig:...> attribute", docElement);
+
+        String rawDoc = provider.generateDoc(docElement, myFixture.getFile().findElementAt(offset));
+        assertNotNull(rawDoc);
+
+        // the doc is HTML with XML-escaped values (e.g. ' -> &#39;), unescape to assert on the source form
+        String doc = StringUtil.unescapeXmlEntities(rawDoc);
+        assertTrue("Expected the prop type", doc.contains("'default'|'destructive'"));
+        assertTrue("Expected the default value from {% props %}", doc.contains("Default: <code>'default'</code>"));
+        assertTrue("Expected the description", doc.contains("The visual style variant."));
+    }
+
+    public void testNonTwigAttributeIsNotDocumented() {
+        myFixture.configureByText(TwigFileType.INSTANCE, "<div variant<caret>=\"\"></div>");
+        int offset = myFixture.getCaretOffset();
+
+        TwigComponentAttributeDocumentationProvider provider = new TwigComponentAttributeDocumentationProvider();
+        assertNull(provider.getCustomDocumentationElement(
+            myFixture.getEditor(), myFixture.getFile(), myFixture.getFile().findElementAt(offset), offset
+        ));
+    }
+}

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
@@ -803,6 +803,39 @@ public class UxUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         assertEquals("Should only have 2 props", 2, props.size());
     }
 
+    public void testGetComponentTemplatePropDefaults() {
+        // defaults are read as written; required props (no "=") are excluded
+        assertEquals(
+            Map.of("open", "false", "variant", "'brand'", "as", "'div'"),
+            propDefaults("{%- props open = false, variant = 'brand', as = 'div' -%}")
+        );
+
+        Map<String, String> withRequired = propDefaults("{% props id, open = false %}");
+        assertEquals("false", withRequired.get("open"));
+        assertFalse("required prop without a default is excluded", withRequired.containsKey("id"));
+
+        // commas inside arrays and strings must not split props
+        Map<String, String> nested = propDefaults("{% props items = ['x', 'y'], label = 'a, b', open = false %}");
+        assertEquals("['x', 'y']", nested.get("items"));
+        assertEquals("'a, b'", nested.get("label"));
+        assertEquals("false", nested.get("open"));
+
+        // bare literals stay bare
+        assertEquals(Map.of("count", "0", "name", "null"), propDefaults("{% props count = 0, name = null %}"));
+
+        // non-literal default expression is kept verbatim
+        assertEquals("foo ~ bar", propDefaults("{% props label = foo ~ bar %}").get("label"));
+
+        // no props tag / other tags contribute nothing
+        assertTrue(propDefaults("<div>{{ foo }}</div>").isEmpty());
+        assertTrue(propDefaults("{% set foo = 'bar' %}").isEmpty());
+    }
+
+    private Map<String, String> propDefaults(@NotNull String source) {
+        TwigFile twigFile = (TwigFile) myFixture.configureByText(TwigFileType.INSTANCE, source);
+        return UxUtil.getComponentTemplatePropDefaults(twigFile);
+    }
+
     private void configureTwigNamespaceSettings(@NotNull TwigNamespaceSetting... settings) {
         Settings.getInstance(getProject()).twigNamespaces.clear();
         Settings.getInstance(getProject()).twigNamespaces.addAll(List.of(settings));

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
@@ -836,6 +836,34 @@ public class UxUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         return UxUtil.getComponentTemplatePropDefaults(twigFile);
     }
 
+    public void testGetComponentTemplateProps() {
+        TwigFile twigFile = (TwigFile) myFixture.configureByText(
+            TwigFileType.INSTANCE,
+            "{# @prop id string Unique identifier. #}\n" +
+            "{# @prop variant 'default'|'destructive' The visual style variant. #}\n" +
+            "{# @block content The content. #}\n" +
+            "{%- props id, variant = 'default' -%}"
+        );
+
+        Map<String, UxUtil.TwigComponentProp> props = UxUtil.getComponentTemplateProps(twigFile);
+
+        UxUtil.TwigComponentProp variant = props.get("variant");
+        assertNotNull(variant);
+        assertEquals("'default'|'destructive'", variant.type());
+        assertEquals("The visual style variant.", variant.description());
+        assertEquals("'default'", variant.defaultValue());
+
+        // required prop (declared without a default in {% props %})
+        UxUtil.TwigComponentProp id = props.get("id");
+        assertNotNull(id);
+        assertEquals("string", id.type());
+        assertEquals("Unique identifier.", id.description());
+        assertNull(id.defaultValue());
+
+        // @block is not a prop
+        assertFalse(props.containsKey("content"));
+    }
+
     private void configureTwigNamespaceSettings(@NotNull TwigNamespaceSetting... settings) {
         Settings.getInstance(getProject()).twigNamespaces.clear();
         Settings.getInstance(getProject()).twigNamespaces.addAll(List.of(settings));


### PR DESCRIPTION
Replaces #2545 (https://github.com/twigphp/Twig/pull/4770 was not a success) and closes #2544. Related to symfony/ux#3694.

Symfony UX Toolkit documents Twig components with `{# @prop #}` and `{# @block #}` docblock comments placed right above the `{%- props -%}` tag, for example `{# @prop orientation 'horizontal'|'vertical' The layout direction. #}` followed by `{%- props orientation = 'horizontal' -%}`.
The docblock carries the name, type and description, while the default value lives in the `{% props %}` tag itself (the single source of truth).

This format, and reading defaults from `{% props %}`, was finalized in symfony/ux#3694.

This PR started out as a small syntax highlighting fix but grew into three related IDE capabilities built around that format.

### Syntax highlighting

`{# @prop #}` and `{# @block #}` comments now get colored: the `@prop`/`@block` keyword, the prop or block name, and the type, reusing PHP's PHPDoc colors (the same ones used for `@property`).

<img width="836" height="372" alt="Capture d’écran 2026-07-05 à 20 27 25" src="https://github.com/user-attachments/assets/6e26ef98-e68f-4e92-bf80-535a2c658314" />

### Prop documentation

Hovering the prop name inside a `{# @prop #}` comment in the component template shows a tooltip with its type, default value (read from `{%- props -%}`) and description. The same information is now available at the usage site too: Ctrl-hover or Ctrl-Q (Quick Documentation) on a component attribute, for example `orientation` in `<twig:Accordion orientation="">`, brings up the same popup.

https://github.com/user-attachments/assets/442bcee8-88d9-4a4c-9d03-d77760c35504


### Attribute completion

Completion inside `<twig:Component ...>` now triggers with Ctrl-Space right after the tag name and a space, before typing any letter. Each suggested prop also shows its type on the right, matching what PHP-class-backed props already did.

https://github.com/user-attachments/assets/bef63a79-4da1-4c39-bd35-4a58c1f1573e


