### PR TITLE
Rework UX component prop/block docs for Twig 3.29 comment syntax

### DIFF
--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/annotation/TwigUxToolkitAnnotator.java
@@ -3,16 +3,20 @@ package fr.adrienbrault.idea.symfony2plugin.templating.annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
 import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.CachedValueProvider;
 import com.intellij.psi.util.CachedValuesManager;
 import com.jetbrains.php.lang.highlighter.PhpHighlightingData;
 import com.jetbrains.twig.TwigFile;
+import com.jetbrains.twig.TwigHighlighterData;
 import com.jetbrains.twig.TwigTokenTypes;
+import com.jetbrains.twig.elements.TwigElementTypes;
 import fr.adrienbrault.idea.symfony2plugin.Symfony2ProjectComponent;
 import fr.adrienbrault.idea.symfony2plugin.util.UxUtil;
 import org.jetbrains.annotations.NotNull;
@@ -20,32 +24,35 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Provides syntax highlighting for Symfony UX Toolkit Twig comment annotations.
+ * Syntax highlighting for Symfony UX Toolkit Twig documentation comments (Twig 3.29 {@code ##} comments):
  *
- * Supports:
- * - {# @prop name type Description #}
- * - {# @block name Description #}
+ * <ul>
+ *   <li>inline prop docs {@code ## <type> <description>} inside a {@code {% props %}} tag: the type token is
+ *       coloured like a PHPDoc type and carries a tooltip with the prop's default value and description;</li>
+ *   <li>block docs {@code {## <description> #}} preceding a {@code {% block %}}: the {@code ##} marker is
+ *       coloured to set it apart from a regular {@code {# #}} comment.</li>
+ * </ul>
  *
- * Uses PHP's PHPDoc highlighting colors for consistency with `@property` annotations.
+ * <p>The bundled Twig lexer does not tokenize inline {@code ##} comments inside a {@code {% %}} block, so
+ * prop docs are highlighted by scanning the tag's raw text rather than from comment PSI tokens.
  *
  * @see <a href="https://github.com/symfony/ux-toolkit">Symfony UX Toolkit</a>
+ * @see <a href="https://github.com/twigphp/Twig/pull/4871">twigphp/Twig#4871</a>
  */
 public class TwigUxToolkitAnnotator implements Annotator {
-    /**
-     * Pattern for @block annotations.
-     * Format: @block name Description
-     * Example: @block content The item content.
-     *
-     * @see <a href="https://regex101.com/r/jYjXpq/1">Regex101</a>
-     */
-    private static final Pattern BLOCK_PATTERN = Pattern.compile(
-        "(@block)\\s+(\\w+)\\s+(.+?)\\s*$",
-        Pattern.DOTALL
-    );
+    /** Head of a {@code {% props %}} tag, used to skip every other Twig tag quickly. */
+    private static final Pattern PROPS_TAG_HEAD = Pattern.compile("^\\{%-?\\s*props\\b");
+
+    /** A whole inline prop-doc line: group 1 the {@code ##} marker, group 2 the type token. */
+    private static final Pattern PROP_DOC_LINE = Pattern.compile("(##)[ \\t]*(\\S+)?[^\\n]*");
+
+    /** An identifier, used to find the prop that an inline doc line documents. */
+    private static final Pattern IDENTIFIER = Pattern.compile("\\w+");
 
     @Override
     public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
@@ -53,158 +60,134 @@ public class TwigUxToolkitAnnotator implements Annotator {
             return;
         }
 
-        // Only process Twig comment text tokens
-        if (element.getNode().getElementType() != TwigTokenTypes.COMMENT_TEXT) {
-            return;
-        }
-
-        String text = element.getText();
-        int startOffset = element.getTextRange().getStartOffset();
-
-        // Try to match @prop pattern
-        Matcher propMatcher = UxUtil.PROP_PATTERN.matcher(text);
-        if (propMatcher.find()) {
-            annotateProp(holder, startOffset, propMatcher, getPropDefaults(element));
-            return;
-        }
-
-        // Try to match @block pattern
-        Matcher blockMatcher = BLOCK_PATTERN.matcher(text);
-        if (blockMatcher.find()) {
-            annotateBlock(holder, startOffset, blockMatcher);
+        IElementType elementType = element.getNode().getElementType();
+        if (elementType == TwigElementTypes.TAG) {
+            annotatePropsTag(element, holder);
+        } else if (elementType == TwigTokenTypes.COMMENT_TEXT) {
+            annotateBlockDoc(element, holder);
         }
     }
 
     /**
-     * Annotates a @prop comment with syntax highlighting.
-     * Highlights: @prop keyword, property name, and type.
-     *
-     * Uses PHP PHPDoc colors:
-     * - DOC_TAG for @prop keyword (like @property in PHPDoc)
-     * - DOC_PROPERTY_IDENTIFIER for property name (like $foo in @property string $foo)
-     * - DOC_IDENTIFIER for type (like string in @property string $foo)
-     *
-     * The property name also carries a hover tooltip with its type, default value (sourced from the
-     * {@code {% props %}} tag, the single source of truth for defaults) and description.
+     * Colours each inline {@code ## <type> <description>} prop doc inside a {@code {% props %}} tag: the
+     * {@code ##} marker (like a PHPDoc {@code @tag}) and the type token (like a PHPDoc type), the latter
+     * with a tooltip resolved from the documented prop.
      */
-    private void annotateProp(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher, @NotNull Map<String, String> propDefaults) {
-        // Highlight @prop keyword (group 1) - like @property
-        highlightRange(holder, startOffset, matcher, 1, PhpHighlightingData.DOC_TAG);
+    private void annotatePropsTag(@NotNull PsiElement tag, @NotNull AnnotationHolder holder) {
+        String text = tag.getText();
+        if (!PROPS_TAG_HEAD.matcher(text).find()) {
+            return;
+        }
 
-        // Highlight property name (group 2) - like $foo in @property string $foo - with a hover tooltip
-        String name = matcher.group(2);
-        String defaultValue = name != null ? propDefaults.get(name) : null;
-        String tooltip = buildPropTooltip(name, matcher.group(3), matcher.group(4), defaultValue);
-        highlightRangeWithTooltip(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER, tooltip);
+        int base = tag.getTextRange().getStartOffset();
 
-        // Highlight type (group 3) - like string in @property string $foo
-        highlightRange(holder, startOffset, matcher, 3, PhpHighlightingData.DOC_IDENTIFIER);
+        Matcher matcher = PROP_DOC_LINE.matcher(text);
+        if (!matcher.find()) {
+            return;
+        }
+
+        // The bundled Twig lexer stops applying the {% %} tag background from the first inline '#'
+        // onward; repaint it (background only) across the whole tag so the doc comments do not punch a
+        // hole in the tag background.
+        highlight(holder, base, base + text.length(), TwigHighlighterData.TWIG_TEMPLATE, null);
+
+        Map<String, UxUtil.TwigComponentProp> props = getProps(tag);
+
+        do {
+            highlight(holder, base + matcher.start(1), base + matcher.end(1), PhpHighlightingData.DOC_TAG, null);
+
+            int descriptionStart = matcher.end(1);
+            if (matcher.group(2) != null) {
+                UxUtil.TwigComponentProp prop = props.get(nextPropName(text, matcher.end(), props.keySet()));
+                String tooltip = prop != null ? buildPropTooltip(prop) : null;
+                highlight(holder, base + matcher.start(2), base + matcher.end(2), PhpHighlightingData.DOC_IDENTIFIER, tooltip);
+                descriptionStart = matcher.end(2);
+            }
+
+            // render the description like a comment so the type stands out (the bundled lexer would
+            // otherwise mis-tokenize these words as code inside the {% props %} tag)
+            if (matcher.end() > descriptionStart) {
+                highlight(holder, base + descriptionStart, base + matcher.end(), DefaultLanguageHighlighterColors.DOC_COMMENT, null);
+            }
+        } while (matcher.find());
     }
 
     /**
-     * Reads the prop default values declared in the template's {@code {% props %}} tag, cached per file.
+     * Colours the {@code ##} marker of a block doc comment {@code {## <description> #}} (which the Twig
+     * lexer exposes as a {@code COMMENT_TEXT} starting with {@code #}) to set it apart from a plain comment.
      */
-    private static @NotNull Map<String, String> getPropDefaults(@NotNull PsiElement element) {
+    private void annotateBlockDoc(@NotNull PsiElement commentText, @NotNull AnnotationHolder holder) {
+        String text = commentText.getText();
+        if (!text.startsWith("#")) {
+            return;
+        }
+
+        int start = commentText.getTextRange().getStartOffset();
+        int markerEnd = text.length() > 1 && text.charAt(1) == '#' ? 2 : 1;
+        highlight(holder, start, start + markerEnd, PhpHighlightingData.DOC_TAG, null);
+    }
+
+    private static @Nullable String nextPropName(@NotNull String text, int from, @NotNull Set<String> names) {
+        Matcher matcher = IDENTIFIER.matcher(text);
+        if (!matcher.find(from)) {
+            return null;
+        }
+
+        do {
+            if (names.contains(matcher.group())) {
+                return matcher.group();
+            }
+        } while (matcher.find());
+
+        return null;
+    }
+
+    private static @NotNull Map<String, UxUtil.TwigComponentProp> getProps(@NotNull PsiElement element) {
         PsiFile file = element.getContainingFile();
         if (!(file instanceof TwigFile twigFile)) {
             return Collections.emptyMap();
         }
 
         return CachedValuesManager.getCachedValue(twigFile, () ->
-            CachedValueProvider.Result.create(UxUtil.getComponentTemplatePropDefaults(twigFile), twigFile)
+            CachedValueProvider.Result.create(UxUtil.getComponentTemplateProps(twigFile), twigFile)
         );
     }
 
-    /**
-     * Builds the hover tooltip for a prop: {@code name : type = default} followed by its description.
-     */
-    private static @NotNull String buildPropTooltip(@Nullable String name, @Nullable String type, @Nullable String description, @Nullable String defaultValue) {
+    private static @NotNull String buildPropTooltip(@NotNull UxUtil.TwigComponentProp prop) {
         StringBuilder tooltip = new StringBuilder();
+        tooltip.append("<code>").append(StringUtil.escapeXmlEntities(prop.name())).append("</code>");
 
-        if (name != null) {
-            tooltip.append("<code>").append(StringUtil.escapeXmlEntities(name)).append("</code>");
+        if (!prop.type().isBlank()) {
+            tooltip.append(" : <code>").append(StringUtil.escapeXmlEntities(prop.type())).append("</code>");
         }
-
-        if (type != null) {
-            tooltip.append(" : <code>").append(StringUtil.escapeXmlEntities(type)).append("</code>");
+        if (prop.defaultValue() != null) {
+            tooltip.append(" = <code>").append(StringUtil.escapeXmlEntities(prop.defaultValue())).append("</code>");
         }
-
-        if (defaultValue != null) {
-            tooltip.append(" = <code>").append(StringUtil.escapeXmlEntities(defaultValue)).append("</code>");
-        }
-
-        if (description != null && !description.isBlank()) {
-            tooltip.append("<br/>").append(StringUtil.escapeXmlEntities(description.trim().replaceAll("\\s+", " ")));
+        if (!prop.description().isBlank()) {
+            tooltip.append("<br/>").append(StringUtil.escapeXmlEntities(prop.description()));
         }
 
         return tooltip.toString();
     }
 
     /**
-     * Like {@link #highlightRange} but attaches a hover tooltip (which {@code newSilentAnnotation} cannot carry).
+     * Silent when there is no tooltip; otherwise an INFORMATION annotation that can carry one
+     * ({@code newSilentAnnotation} cannot).
      */
-    private void highlightRangeWithTooltip(
-        @NotNull AnnotationHolder holder,
-        int baseOffset,
-        @NotNull Matcher matcher,
-        int group,
-        @NotNull TextAttributesKey textAttributesKey,
-        @NotNull String tooltip
-    ) {
-        if (matcher.group(group) == null) {
-            return;
+    private void highlight(@NotNull AnnotationHolder holder, int start, int end, @NotNull TextAttributesKey key, @Nullable String tooltip) {
+        TextRange range = new TextRange(start, end);
+
+        if (tooltip == null) {
+            holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .range(range)
+                .textAttributes(key)
+                .create();
+        } else {
+            holder.newAnnotation(HighlightSeverity.INFORMATION, StringUtil.removeHtmlTags(tooltip))
+                .range(range)
+                .tooltip(tooltip)
+                .textAttributes(key)
+                .create();
         }
-
-        TextRange range = new TextRange(
-            baseOffset + matcher.start(group),
-            baseOffset + matcher.end(group)
-        );
-
-        holder.newAnnotation(HighlightSeverity.INFORMATION, StringUtil.removeHtmlTags(tooltip))
-            .range(range)
-            .tooltip(tooltip)
-            .textAttributes(textAttributesKey)
-            .create();
-    }
-
-    /**
-     * Annotates a @block comment with syntax highlighting.
-     * Highlights: @block keyword and block name.
-     *
-     * Uses PHP PHPDoc colors:
-     * - DOC_TAG for @block keyword
-     * - DOC_PROPERTY_IDENTIFIER for block name
-     */
-    private void annotateBlock(@NotNull AnnotationHolder holder, int startOffset, @NotNull Matcher matcher) {
-        // Highlight @block keyword (group 1)
-        highlightRange(holder, startOffset, matcher, 1, PhpHighlightingData.DOC_TAG);
-
-        // Highlight block name (group 2)
-        highlightRange(holder, startOffset, matcher, 2, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER);
-    }
-
-    /**
-     * Creates a silent annotation with the specified text attributes for a regex group match.
-     */
-    private void highlightRange(
-        @NotNull AnnotationHolder holder,
-        int baseOffset,
-        @NotNull Matcher matcher,
-        int group,
-        @NotNull TextAttributesKey textAttributesKey
-    ) {
-        if (matcher.group(group) == null) {
-            return;
-        }
-
-        TextRange range = new TextRange(
-            baseOffset + matcher.start(group),
-            baseOffset + matcher.end(group)
-        );
-
-        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-            .range(range)
-            .textAttributes(textAttributesKey)
-            .create();
     }
 }

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/completion/TwigHtmlCompletionContributor.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/completion/TwigHtmlCompletionContributor.java
@@ -402,13 +402,17 @@ public class TwigHtmlCompletionContributor extends CompletionContributor {
                     }
 
                     // Add completion for {% props %} defined in component templates, showing the prop
-                    // type (from its {# @prop #} docblock) on the right when available.
+                    // type (from its "## <type> <description>" doc comment) on the right when available.
                     String componentName = name.substring(5);
 
                     Map<String, String> propTypes = new HashMap<>();
                     for (PsiFile template : UxUtil.getComponentTemplates(position.getProject(), componentName)) {
                         if (template instanceof TwigFile twigFile) {
-                            UxUtil.getComponentTemplateProps(twigFile).forEach((propName, prop) -> propTypes.putIfAbsent(propName, prop.type()));
+                            UxUtil.getComponentTemplateProps(twigFile).forEach((propName, prop) -> {
+                                if (!prop.type().isBlank()) {
+                                    propTypes.putIfAbsent(propName, prop.type());
+                                }
+                            });
                         }
                     }
 

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/documentation/TwigComponentAttributeDocumentationProvider.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/templating/documentation/TwigComponentAttributeDocumentationProvider.java
@@ -19,8 +19,8 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Documentation for Symfony UX Twig component props on their usage, e.g. Ctrl-hover / Ctrl-Q on the
  * {@code variant} attribute of {@code <twig:Alert variant="">}. The prop's type and description come
- * from the component template's {@code {# @prop #}} docblock and its default value from the
- * {@code {%- props -%}} tag ({@link UxUtil#getComponentTemplateProps}).
+ * from the inline {@code ## <type> <description>} doc comment inside the component template's
+ * {@code {% props %}} tag, and its default value from the same tag ({@link UxUtil#getComponentTemplateProps}).
  *
  * <p>Registered for HTML because the {@code <twig:...>} attribute leaf is HTML in the {@code .html.twig}
  * view. Returns {@code null} for anything that is not a {@code twig:} component attribute, so the
@@ -61,8 +61,11 @@ public class TwigComponentAttributeDocumentationProvider extends AbstractDocumen
         }
 
         StringBuilder doc = new StringBuilder();
-        doc.append("<code>").append(escape(prop.name())).append("</code>")
-            .append(" : <code>").append(escape(prop.type())).append("</code>");
+        doc.append("<code>").append(escape(prop.name())).append("</code>");
+
+        if (!prop.type().isBlank()) {
+            doc.append(" : <code>").append(escape(prop.type())).append("</code>");
+        }
 
         if (prop.defaultValue() != null) {
             doc.append("<br/>Default: <code>").append(escape(prop.defaultValue())).append("</code>");
@@ -83,8 +86,11 @@ public class TwigComponentAttributeDocumentationProvider extends AbstractDocumen
         }
 
         StringBuilder info = new StringBuilder();
-        info.append("<code>").append(escape(prop.name())).append("</code>")
-            .append(" : <code>").append(escape(prop.type())).append("</code>");
+        info.append("<code>").append(escape(prop.name())).append("</code>");
+
+        if (!prop.type().isBlank()) {
+            info.append(" : <code>").append(escape(prop.type())).append("</code>");
+        }
 
         if (prop.defaultValue() != null) {
             info.append(" = <code>").append(escape(prop.defaultValue())).append("</code>");

--- a/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
+++ b/src/main/java/fr/adrienbrault/idea/symfony2plugin/util/UxUtil.java
@@ -798,178 +798,165 @@ public class UxUtil {
     }
 
     public static void visitComponentTemplateProps(@NotNull TwigFile twigFile, @NotNull Consumer<Pair<String, PsiElement>> consumer) {
-        for (PsiElement element : twigFile.getChildren()) {
-            if (element instanceof TwigCompositeElement && element.getNode().getElementType() == TwigElementTypes.TAG) {
-                PsiElement firstChild1 = element.getFirstChild();
-                if (firstChild1 == null) {
-                    continue;
-                }
-
-                PsiElement tagName = PsiElementUtils.getNextSiblingAndSkip(firstChild1, TwigTokenTypes.TAG_NAME);
-                if (tagName == null) {
-                    continue;
-                }
-
-                ASTNode nextNonWhitespaceLeaf = FormatterUtil.getNextNonWhitespaceLeaf(tagName.getNode());
-                if (nextNonWhitespaceLeaf == null || nextNonWhitespaceLeaf.getElementType() != TwigTokenTypes.IDENTIFIER) {
-                    continue;
-                }
-
-                String text = nextNonWhitespaceLeaf.getText();
-                if (!text.isBlank()) {
-                    consumer.accept(new Pair<>(text, nextNonWhitespaceLeaf.getPsi()));
-                }
-
-                for (PsiElement commaPsi : PsiElementUtils.getChildrenOfTypeAsList(element, PlatformPatterns.psiElement().withElementType(TwigTokenTypes.COMMA))) {
-                    ASTNode propName = FormatterUtil.getNextNonWhitespaceLeaf(commaPsi.getNode());
-                    if (propName == null || propName.getElementType() != TwigTokenTypes.IDENTIFIER) {
-                        continue;
-                    }
-
-                    String propText = propName.getText();
-                    if (!propText.isBlank()) {
-                        consumer.accept(new Pair<>(propText, propName.getPsi()));
-                    }
-                }
-            }
+        for (ParsedProp prop : parseComponentTemplateProps(twigFile)) {
+            PsiElement target = prop.nameOffset() >= 0 ? twigFile.findElementAt(prop.nameOffset()) : null;
+            consumer.accept(new Pair<>(prop.name(), target != null ? target : twigFile));
         }
     }
 
     /**
-     * Extracts the prop default values from a component template's {@code {%- props -%}} tag.
-     *
-     * <p>Default values live only in the {@code {%- props -%}} declaration (the single source of
-     * truth), the same way Symfony UX Toolkit's {@code ComponentDocParser} sources them rather than
-     * from the {@code {# @prop #}} docblock. Each default is returned as written in the source
-     * (e.g. {@code false}, {@code 'brand'}, {@code ['a', 'b']}); commas inside arrays, hashes and
-     * strings are handled because the Twig parser nests them, so only the tag's top-level commas
-     * separate props. Props declared without a default (required props) are not included.
-     *
-     * @return prop name to its default expression, in declaration order
-     */
-    @NotNull
-    public static Map<String, String> getComponentTemplatePropDefaults(@NotNull TwigFile twigFile) {
-        Map<String, String> defaults = new LinkedHashMap<>();
-
-        for (PsiElement element : twigFile.getChildren()) {
-            if (!(element instanceof TwigCompositeElement) || element.getNode().getElementType() != TwigElementTypes.TAG) {
-                continue;
-            }
-
-            ASTNode[] children = element.getNode().getChildren(null);
-
-            int nameIndex = -1;
-            for (int i = 0; i < children.length; i++) {
-                if (children[i].getElementType() == TwigTokenTypes.TAG_NAME) {
-                    nameIndex = i;
-                    break;
-                }
-            }
-
-            if (nameIndex == -1 || !"props".equals(children[nameIndex].getText().trim())) {
-                continue;
-            }
-
-            List<ASTNode> segment = new ArrayList<>();
-            for (int i = nameIndex + 1; i < children.length; i++) {
-                IElementType type = children[i].getElementType();
-                if (type == TwigTokenTypes.STATEMENT_BLOCK_END) {
-                    break;
-                }
-
-                if (type == TwigTokenTypes.COMMA) {
-                    collectPropDefault(segment, defaults);
-                    segment.clear();
-                } else {
-                    segment.add(children[i]);
-                }
-            }
-            collectPropDefault(segment, defaults);
-
-            return defaults;
-        }
-
-        return defaults;
-    }
-
-    private static void collectPropDefault(@NotNull List<ASTNode> segment, @NotNull Map<String, String> defaults) {
-        String name = null;
-        int equalIndex = -1;
-
-        for (int i = 0; i < segment.size(); i++) {
-            ASTNode node = segment.get(i);
-            if (node.getText().isBlank()) {
-                continue;
-            }
-
-            if (name == null) {
-                if (node.getElementType() != TwigTokenTypes.IDENTIFIER) {
-                    return;
-                }
-                name = node.getText();
-            } else if (node.getElementType() == TwigTokenTypes.EQ) {
-                equalIndex = i;
-                break;
-            }
-        }
-
-        if (name == null || equalIndex == -1) {
-            return;
-        }
-
-        StringBuilder defaultValue = new StringBuilder();
-        for (int i = equalIndex + 1; i < segment.size(); i++) {
-            defaultValue.append(segment.get(i).getText());
-        }
-
-        String trimmed = defaultValue.toString().trim();
-        if (!trimmed.isEmpty()) {
-            defaults.put(name, trimmed);
-        }
-    }
-
-    /**
-     * Pattern for a Symfony UX Toolkit {@code {# @prop name type description #}} docblock.
-     * Group 1: {@code @prop}, group 2: name, group 3: type, group 4: description.
-     *
-     * @see <a href="https://regex101.com/r/3JXNX7/1">Regex101</a>
-     */
-    public static final Pattern PROP_PATTERN = Pattern.compile(
-        "(@prop)\\s+(\\w+)\\s+(\\S+)\\s+(.+?)\\s*$",
-        Pattern.DOTALL
-    );
-
-    /**
-     * A prop documented in a component template: its {@code {# @prop name type description #}} docblock
-     * merged with the default value declared in the {@code {%- props -%}} tag.
+     * A prop documented in a component template: the inline {@code ## <type> <description>} documentation
+     * comment (Twig 3.29 documentation comment) merged with the default value declared in the same
+     * {@code {% props %}} tag. {@code type} and {@code description} are empty when the prop has no doc comment.
      */
     public record TwigComponentProp(@NotNull String name, @NotNull String type, @NotNull String description, @Nullable String defaultValue) {}
 
     /**
-     * Parses a component template's {@code {# @prop name type description #}} docblocks and merges each
-     * prop's default value from the {@code {%- props -%}} tag ({@link #getComponentTemplatePropDefaults}).
+     * Matches a whole {@code {%- props ... -%}} tag; group 1 is the body between {@code props} and the close.
+     */
+    private static final Pattern PROPS_TAG_PATTERN = Pattern.compile("\\{%-?\\s*props\\b(.*?)-?%}", Pattern.DOTALL);
+
+    /**
+     * A single prop declaration {@code name} or {@code name = default}; group 1 is the name, group 2 the
+     * default expression as written (or {@code null} for a required prop).
+     */
+    private static final Pattern PROP_DECLARATION_PATTERN = Pattern.compile("^(\\w+)\\s*(?:=\\s*(.*))?$", Pattern.DOTALL);
+
+    /**
+     * Parses a component template's {@code {% props %}} tag. Every declared prop is returned with the
+     * default value written after {@code =} (required props keep {@code null}) and, when present, the
+     * {@code ## <type> <description>} documentation comment that precedes it: the type is the first
+     * whitespace-delimited token, the rest is the description (the Symfony UX Toolkit convention).
      *
-     * @return prop name to its documentation, in docblock order
+     * <p>The bundled IntelliJ Twig lexer does not tokenize inline {@code #}/{@code ##} comments inside a
+     * {@code {% %}} block, so the tag is read from its raw text: top-level commas separate props (commas
+     * nested in strings, arrays and hashes do not) and a {@code #} starts a comment running to end of line.
+     *
+     * @return prop name to its documentation, in declaration order
      */
     @NotNull
     public static Map<String, TwigComponentProp> getComponentTemplateProps(@NotNull TwigFile twigFile) {
-        Map<String, String> defaults = getComponentTemplatePropDefaults(twigFile);
         Map<String, TwigComponentProp> props = new LinkedHashMap<>();
+        for (ParsedProp prop : parseComponentTemplateProps(twigFile)) {
+            props.put(prop.name(), new TwigComponentProp(prop.name(), prop.type(), prop.description(), prop.defaultValue()));
+        }
+        return props;
+    }
 
-        for (PsiElement comment : PsiTreeUtil.collectElements(twigFile, element -> element.getNode().getElementType() == TwigTokenTypes.COMMENT_TEXT)) {
-            Matcher matcher = PROP_PATTERN.matcher(comment.getText());
-            if (matcher.find()) {
-                String name = matcher.group(2);
-                props.put(name, new TwigComponentProp(
-                    name,
-                    matcher.group(3),
-                    matcher.group(4).trim().replaceAll("\\s+", " "),
-                    defaults.get(name)
-                ));
-            }
+    /**
+     * A prop parsed from the {@code {% props %}} tag, plus {@code nameOffset}: the absolute file offset of
+     * the name token (or {@code -1} if unknown), used to resolve a navigable PSI element.
+     */
+    private record ParsedProp(@NotNull String name, @NotNull String type, @NotNull String description, @Nullable String defaultValue, int nameOffset) {}
+
+    /**
+     * Scans the component's {@code {% props %}} tag once from its raw text (see {@link #getComponentTemplateProps}
+     * for why PSI tokens cannot be trusted here) and returns every declared prop in declaration order.
+     */
+    @NotNull
+    private static List<ParsedProp> parseComponentTemplateProps(@NotNull TwigFile twigFile) {
+        Matcher tag = PROPS_TAG_PATTERN.matcher(twigFile.getText());
+        if (!tag.find()) {
+            return Collections.emptyList();
         }
 
+        int bodyStart = tag.start(1);
+        String body = tag.group(1);
+
+        List<ParsedProp> props = new ArrayList<>();
+        List<String> pendingDoc = new ArrayList<>();
+        StringBuilder segment = new StringBuilder();
+        int segmentStart = -1;
+        int depth = 0;
+        char quote = 0;
+
+        for (int i = 0; i < body.length(); i++) {
+            char c = body.charAt(i);
+
+            if (segmentStart == -1 && quote == 0 && c != '#' && !Character.isWhitespace(c)) {
+                segmentStart = i;
+            }
+
+            if (quote != 0) {
+                segment.append(c);
+                if (c == quote) {
+                    quote = 0;
+                }
+            } else if (c == '\'' || c == '"') {
+                quote = c;
+                segment.append(c);
+            } else if (c == '#') {
+                // Twig inline comment: runs to end of line; a "##" comment documents the next prop.
+                int end = body.indexOf('\n', i);
+                if (end == -1) {
+                    end = body.length();
+                }
+                if (depth == 0 && i + 1 < body.length() && body.charAt(i + 1) == '#') {
+                    String doc = body.substring(i + 2, end).trim();
+                    if (!doc.isEmpty()) {
+                        pendingDoc.add(doc);
+                    }
+                }
+                i = end - 1;
+            } else if (c == '(' || c == '[' || c == '{') {
+                depth++;
+                segment.append(c);
+            } else if (c == ')' || c == ']' || c == '}') {
+                depth--;
+                segment.append(c);
+            } else if (c == ',' && depth == 0) {
+                collectParsedProp(segment, segmentStart, bodyStart, pendingDoc, props);
+                segmentStart = -1;
+            } else {
+                segment.append(c);
+            }
+        }
+        collectParsedProp(segment, segmentStart, bodyStart, pendingDoc, props);
+
         return props;
+    }
+
+    private static void collectParsedProp(@NotNull StringBuilder segment, int segmentStart, int bodyStart, @NotNull List<String> pendingDoc, @NotNull List<ParsedProp> props) {
+        String code = segment.toString().trim();
+        segment.setLength(0);
+
+        String doc = String.join(" ", pendingDoc).trim();
+        pendingDoc.clear();
+
+        Matcher matcher = PROP_DECLARATION_PATTERN.matcher(code);
+        if (!matcher.matches()) {
+            return;
+        }
+
+        String defaultValue = matcher.group(2) != null ? matcher.group(2).trim() : null;
+        if (defaultValue != null && defaultValue.isEmpty()) {
+            defaultValue = null;
+        }
+
+        String type = "";
+        String description = "";
+        if (!doc.isEmpty()) {
+            String[] parts = doc.split("\\s+", 2);
+            type = parts[0];
+            description = parts.length > 1 ? parts[1].trim().replaceAll("\\s+", " ") : "";
+        }
+
+        int nameOffset = segmentStart >= 0 ? bodyStart + segmentStart : -1;
+        props.add(new ParsedProp(matcher.group(1), type, description, defaultValue, nameOffset));
+    }
+
+    /**
+     * Prop name to its default value (as written) for every prop that declares one; required props are excluded.
+     */
+    @NotNull
+    public static Map<String, String> getComponentTemplatePropDefaults(@NotNull TwigFile twigFile) {
+        Map<String, String> defaults = new LinkedHashMap<>();
+        for (TwigComponentProp prop : getComponentTemplateProps(twigFile).values()) {
+            if (prop.defaultValue() != null) {
+                defaults.put(prop.name(), prop.defaultValue());
+            }
+        }
+        return defaults;
     }
 
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/annotation/TwigUxToolkitAnnotatorTest.java
@@ -1,64 +1,40 @@
 package fr.adrienbrault.idea.symfony2plugin.tests.templating.annotation;
 
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.jetbrains.php.lang.highlighter.PhpHighlightingData;
+import com.jetbrains.twig.TwigHighlighterData;
 import fr.adrienbrault.idea.symfony2plugin.templating.annotation.TwigUxToolkitAnnotator;
 import fr.adrienbrault.idea.symfony2plugin.tests.SymfonyLightCodeInsightFixtureTestCase;
 
 import java.util.List;
 
 /**
- * @author Daniel Espendiller <daniel@espendiller.net>
  * @see TwigUxToolkitAnnotator
  */
 public class TwigUxToolkitAnnotatorTest extends SymfonyLightCodeInsightFixtureTestCase {
 
-    public void testPropAnnotationIsHighlighted() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @prop open boolean Whether the item is open by default. #}"
+    public void testInlinePropDocHighlightsMarkerAndType() {
+        List<HighlightInfo> highlighting = highlight(
+            "{%- props\n" +
+            "    ## boolean Whether the item is open by default.\n" +
+            "    open = false,\n" +
+            "-%}"
         );
 
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        // Verify that highlighting is applied (INFORMATION level annotations from our annotator)
+        // the ## marker is coloured like a PHPDoc @tag
         assertTrue(
-            "Expected highlighting for @prop annotation",
+            "Expected the ## marker highlighted",
             highlighting.stream().anyMatch(info ->
                 info.getSeverity().getName().equals("INFORMATION") &&
                 hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
             )
         );
-    }
 
-    public void testPropAnnotationHighlightsPropertyName() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @prop open boolean Whether the item is open by default. #}"
-        );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
+        // the type token is coloured like a PHPDoc type
         assertTrue(
-            "Expected highlighting for property name",
-            highlighting.stream().anyMatch(info ->
-                info.getSeverity().getName().equals("INFORMATION") &&
-                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
-            )
-        );
-    }
-
-    public void testPropAnnotationHighlightsType() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @prop open boolean Whether the item is open by default. #}"
-        );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        assertTrue(
-            "Expected highlighting for type",
+            "Expected the prop type highlighted",
             highlighting.stream().anyMatch(info ->
                 info.getSeverity().getName().equals("INFORMATION") &&
                 hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
@@ -66,121 +42,48 @@ public class TwigUxToolkitAnnotatorTest extends SymfonyLightCodeInsightFixtureTe
         );
     }
 
-    public void testBlockAnnotationIsHighlighted() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @block content The item content. #}"
+    public void testInlinePropDocRepaintsTagBackground() {
+        List<HighlightInfo> highlighting = highlight(
+            "{%- props\n" +
+            "    ## boolean Whether the item is open by default.\n" +
+            "    open = false,\n" +
+            "-%}"
         );
 
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
+        // the {% %} tag background is repainted (the bundled Twig lexer drops it from the first '#')
+        assertTrue(
+            "Expected the tag background repainted with TWIG_TEMPLATE",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, TwigHighlighterData.TWIG_TEMPLATE)
+            )
+        );
+    }
+
+    public void testInlinePropDocHighlightsDescriptionAsComment() {
+        List<HighlightInfo> highlighting = highlight(
+            "{%- props\n" +
+            "    ## boolean Whether the item is open by default.\n" +
+            "    open = false,\n" +
+            "-%}"
+        );
 
         assertTrue(
-            "Expected highlighting for @block annotation",
+            "Expected the description rendered as a comment",
             highlighting.stream().anyMatch(info ->
                 info.getSeverity().getName().equals("INFORMATION") &&
-                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+                hasTextAttributesKey(info, DefaultLanguageHighlighterColors.DOC_COMMENT)
             )
         );
     }
 
-    public void testBlockAnnotationHighlightsBlockName() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @block content The item content. #}"
+    public void testInlinePropDocTooltipShowsTypeDefaultAndDescription() {
+        List<HighlightInfo> highlighting = highlight(
+            "{%- props\n" +
+            "    ## boolean Whether the item is open by default.\n" +
+            "    open = false,\n" +
+            "-%}"
         );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        assertTrue(
-            "Expected highlighting for block name",
-            highlighting.stream().anyMatch(info ->
-                info.getSeverity().getName().equals("INFORMATION") &&
-                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
-            )
-        );
-    }
-
-    public void testPropWithComplexType() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @prop items App\\Entity\\Item[] List of items #}"
-        );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        assertTrue(
-            "Expected highlighting for complex type",
-            highlighting.stream().anyMatch(info ->
-                info.getSeverity().getName().equals("INFORMATION") &&
-                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
-            )
-        );
-    }
-
-    public void testPropWithUnionType() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @prop value string|int|null The value #}"
-        );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        assertTrue(
-            "Expected highlighting for union type",
-            highlighting.stream().anyMatch(info ->
-                info.getSeverity().getName().equals("INFORMATION") &&
-                hasTextAttributesKey(info, PhpHighlightingData.DOC_IDENTIFIER)
-            )
-        );
-    }
-
-    public void testRegularCommentNotHighlighted() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# This is a regular comment #}"
-        );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        // Regular comments should not have our specific highlighting
-        assertFalse(
-            "Regular comments should not have DOC_COMMENT_TAG highlighting",
-            highlighting.stream().anyMatch(info ->
-                info.getSeverity().getName().equals("INFORMATION") &&
-                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
-            )
-        );
-    }
-
-    public void testVarCommentNotAffected() {
-        // @var comments are handled by a different mechanism, ensure we don't interfere
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @var foo \\App\\Entity\\Foo #}"
-        );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        // @var must not receive @prop/@block highlighting from TwigUxToolkitAnnotator.
-        // (@var is coloured by the separate TwigVarCommentAnnotator, which uses different keys;
-        // DOC_PROPERTY_IDENTIFIER is unique to a @prop name, so its absence proves we did not fire.)
-        assertFalse(
-            "@var comments should not be highlighted by TwigUxToolkitAnnotator",
-            highlighting.stream().anyMatch(info ->
-                info.getSeverity().getName().equals("INFORMATION") &&
-                hasTextAttributesKey(info, PhpHighlightingData.DOC_PROPERTY_IDENTIFIER)
-            )
-        );
-    }
-
-    public void testPropTooltipShowsDefaultFromPropsTag() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @prop open boolean Whether the item is open by default. #}\n" +
-            "{%- props open = false -%}"
-        );
-
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
 
         assertTrue(
             "Expected a tooltip carrying the type, default value and description",
@@ -193,16 +96,14 @@ public class TwigUxToolkitAnnotatorTest extends SymfonyLightCodeInsightFixtureTe
         );
     }
 
-    public void testPropTooltipOmitsDefaultForRequiredProp() {
-        myFixture.configureByText(
-            "test.html.twig",
-            "{# @prop id string Unique identifier. #}\n" +
-            "{%- props id -%}"
+    public void testInlinePropDocTooltipOmitsDefaultForRequiredProp() {
+        List<HighlightInfo> highlighting = highlight(
+            "{%- props\n" +
+            "    ## string Unique identifier.\n" +
+            "    id,\n" +
+            "-%}"
         );
 
-        List<HighlightInfo> highlighting = myFixture.doHighlighting();
-
-        // the tooltip still describes the prop...
         assertTrue(
             "Expected a tooltip carrying the type and description",
             highlighting.stream().anyMatch(info ->
@@ -212,13 +113,44 @@ public class TwigUxToolkitAnnotatorTest extends SymfonyLightCodeInsightFixtureTe
             )
         );
 
-        // ...but shows no default assignment for a required prop
         assertFalse(
             "A required prop must not show a default value",
             highlighting.stream().anyMatch(info ->
                 info.getToolTip() != null && info.getToolTip().contains("= <code>")
             )
         );
+    }
+
+    public void testBlockDocMarkerIsHighlighted() {
+        List<HighlightInfo> highlighting = highlight(
+            "{## The item content. #}\n" +
+            "{% block content %}{% endblock %}"
+        );
+
+        assertTrue(
+            "Expected the {## marker highlighted as a documentation comment",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    public void testRegularCommentNotHighlighted() {
+        List<HighlightInfo> highlighting = highlight("{# This is a regular comment #}");
+
+        assertFalse(
+            "A regular comment must not get documentation highlighting",
+            highlighting.stream().anyMatch(info ->
+                info.getSeverity().getName().equals("INFORMATION") &&
+                hasTextAttributesKey(info, PhpHighlightingData.DOC_TAG)
+            )
+        );
+    }
+
+    private List<HighlightInfo> highlight(String content) {
+        myFixture.configureByText("test.html.twig", content);
+        return myFixture.doHighlighting();
     }
 
     /**

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/completion/TwigHtmlCompletionContributorTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/completion/TwigHtmlCompletionContributorTest.java
@@ -109,14 +109,16 @@ public class TwigHtmlCompletionContributorTest extends SymfonyLightCodeInsightFi
     }
 
     /**
-     * Test that a template prop's type (from its {# @prop #} docblock) is shown on the right.
+     * Test that a template prop's type (from its "## <type> <description>" doc comment) is shown on the right.
      */
     public void testThatTemplatePropCompletionShowsTypeFromPropDocblock() {
         myFixture.copyFileToProject("twig_component.yaml", "config/packages/twig_component.yaml");
         myFixture.copyFileToProject("ide-twig.json", "ide-twig.json");
         myFixture.addFileToProject("templates/components/PropsAlert.html.twig",
-            "{# @prop variant 'default'|'destructive' The visual style variant. #}\n" +
-            "{%- props variant = 'default' -%}\n" +
+            "{%- props\n" +
+            "    ## 'default'|'destructive' The visual style variant.\n" +
+            "    variant = 'default',\n" +
+            "-%}\n" +
             "<div></div>"
         );
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/documentation/TwigComponentAttributeDocumentationProviderTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/templating/documentation/TwigComponentAttributeDocumentationProviderTest.java
@@ -19,8 +19,10 @@ public class TwigComponentAttributeDocumentationProviderTest extends SymfonyLigh
         myFixture.copyFileToProject("twig_component.yaml", "config/packages/twig_component.yaml");
         myFixture.copyFileToProject("ide-twig.json", "ide-twig.json");
         myFixture.addFileToProject("templates/components/PropsAlert.html.twig",
-            "{# @prop variant 'default'|'destructive' The visual style variant. #}\n" +
-            "{%- props variant = 'default' -%}\n" +
+            "{%- props\n" +
+            "    ## 'default'|'destructive' The visual style variant.\n" +
+            "    variant = 'default',\n" +
+            "-%}\n" +
             "<div></div>"
         );
 

--- a/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
+++ b/src/test/java/fr/adrienbrault/idea/symfony2plugin/tests/util/UxUtilTest.java
@@ -829,6 +829,18 @@ public class UxUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         // no props tag / other tags contribute nothing
         assertTrue(propDefaults("<div>{{ foo }}</div>").isEmpty());
         assertTrue(propDefaults("{% set foo = 'bar' %}").isEmpty());
+
+        // inline "## <type> <description>" doc comments must not break default extraction
+        Map<String, String> documented = propDefaults(
+            "{%- props\n" +
+            "    ## boolean Whether it is open.\n" +
+            "    open = false,\n" +
+            "    ## string The identifier.\n" +
+            "    id = 'x'\n" +
+            "-%}"
+        );
+        assertEquals("false", documented.get("open"));
+        assertEquals("'x'", documented.get("id"));
     }
 
     private Map<String, String> propDefaults(@NotNull String source) {
@@ -839,10 +851,12 @@ public class UxUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
     public void testGetComponentTemplateProps() {
         TwigFile twigFile = (TwigFile) myFixture.configureByText(
             TwigFileType.INSTANCE,
-            "{# @prop id string Unique identifier. #}\n" +
-            "{# @prop variant 'default'|'destructive' The visual style variant. #}\n" +
-            "{# @block content The content. #}\n" +
-            "{%- props id, variant = 'default' -%}"
+            "{%- props\n" +
+            "    ## string Unique identifier.\n" +
+            "    id,\n" +
+            "    ## 'default'|'destructive' The visual style variant.\n" +
+            "    variant = 'default',\n" +
+            "-%}"
         );
 
         Map<String, UxUtil.TwigComponentProp> props = UxUtil.getComponentTemplateProps(twigFile);
@@ -859,9 +873,19 @@ public class UxUtilTest extends SymfonyLightCodeInsightFixtureTestCase {
         assertEquals("string", id.type());
         assertEquals("Unique identifier.", id.description());
         assertNull(id.defaultValue());
+    }
 
-        // @block is not a prop
-        assertFalse(props.containsKey("content"));
+    public void testGetComponentTemplatePropsWithoutDocCommentHasEmptyTypeAndDescription() {
+        TwigFile twigFile = (TwigFile) myFixture.configureByText(
+            TwigFileType.INSTANCE,
+            "{%- props open = false -%}"
+        );
+
+        UxUtil.TwigComponentProp open = UxUtil.getComponentTemplateProps(twigFile).get("open");
+        assertNotNull(open);
+        assertEquals("", open.type());
+        assertEquals("", open.description());
+        assertEquals("false", open.defaultValue());
     }
 
     private void configureTwigNamespaceSettings(@NotNull TwigNamespaceSetting... settings) {


### PR DESCRIPTION
Following https://github.com/Haehnchen/idea-php-symfony2-plugin/pull/2826, things have changed!

There is a pending PR on Twig that permits to add documentation to Twig Nodes: https://github.com/twigphp/Twig/pull/4871

Obviously, components from UX Toolkit kits that use annotations `@prop` and `@block` will be updated, and will use the `{## ... #}` syntax instead. There is no interest to keep using the old annotation syntax, which is only used by UX Toolkit kits IMHO.

So, this PR remove the support for the old annotation syntax, and add support for the new `{## ... #}` syntax (parsing, color highlighting, completion, etc.).

<img width="808" height="524" alt="Capture d’écran 2026-07-25 à 20 11 32" src="https://github.com/user-attachments/assets/9c8b0abd-3e3b-49f3-8942-38a1e4ec22e1" />
<img width="623" height="234" alt="Capture d’écran 2026-07-25 à 20 11 38" src="https://github.com/user-attachments/assets/2b6eb2ec-5ced-40b2-ab91-b90cfeb8ade2" />
